### PR TITLE
fix: if only 1 cluster `label.clusters` now works

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -3312,7 +3312,13 @@ pgx.scatterPlotXY.PLOTLY <- function(pos,
     ## label cluster
     if(label.clusters) {
         mpos <- apply(pos,2,function(x) tapply(x,z1,median))
-        mlab <- rownames(mpos)
+        # If there is only one cluster
+        if(length(unique(z1))){
+          mpos <- data.frame(mpos[1], mpos[2])
+          mlab <- unique(z1)
+        } else {
+          mlab <- rownames(mpos)
+        }
         ##if(!is.null(labels)) mlab <- labels[rownames(mpos)]
         plt <- plt %>%
             plotly::add_annotations(


### PR DESCRIPTION
When there was only 1 cluster to label the plotting function crashed. Solved it by arranging the numeric vector as a data frame and getting the cluster tab as the unique value of the vector. Fixes OPG Clustering>Samples>Phenotypes when filtering samples.