### PR TITLE
fix: OPG #333: batchcorrection error: Discrete value supplied to continuous scale

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2190,7 +2190,11 @@ plot_ggscatter <- function(x, y=NULL, col=NULL, main=NULL,
             ggplot2::geom_point(size = 2.0*cex) +
             ggplot2::ggtitle(main) + ggplot2::xlab(xlab) + ggplot2::ylab(ylab)
         if(!is.null(col.scale)) {
-            p <- p + ggplot2::scale_color_gradient( low=col.scale[1], high=col.scale[2] )
+            if(class(col) %in% c("numeric", "integer")){
+              p <- p + ggplot2::scale_color_gradient( low=col.scale[1], high=col.scale[2] )
+            } else {
+              p <- p + ggplot2::scale_fill_gradient( low=col.scale[1], high=col.scale[2] )
+            }
         }
     }
     p


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/333

## Cause of the error
When we have a categorical `y1` (class `character` for example), we should not use `ggplot2::scale_color_gradient`. We should use `gplot2::scale_fill_gradient`. This problem happens [here](https://github.com/bigomics/playbase/blob/main/R/pgx-plotting.R#L2193).

## Fix
Use the propper function depending on the class. [Code](https://github.com/bigomics/playbase/compare/fix-%23333_opg?expand=1#diff-160245acbb61e1773d34566d004a348e15ead57c731f5d2ae8420537bdaf9c0eR2193-R2195)

## To reproduce error and see if the fix works
```
pos <- data.frame(
  x = c(1,2,3),
  y = c(4,5,6)
)
y2 <- NULL

# `numeric y1`: Works
y1 <- c(1, 2, 3)
playbase::plot_ggscatter(
  pos, col=y1, shape=y2,
  cex=0.7)

# `integer y1`: Works
y1 <- c(1L, 2L, 3L)
playbase::plot_ggscatter(
  pos, col=y1, shape=y2,
  cex=0.7)

# `character(categorical) y1`: DOES NOT Work
y1 <- c("1L", "1L", "3L")
playbase::plot_ggscatter(
  pos, col=y1, shape=y2,
  cex=0.7)
```