### PR TITLE
Fix #481 (OPG): correlation analysis not working when contrasts are equal

### DIFF
--- a/R/pgx-correlation.R
+++ b/R/pgx-correlation.R
@@ -626,7 +626,6 @@ pgx.getGeneCorrelation <- function(gene, xref) {
 
     rho.genes <- unlist(lapply(xref, rownames))
     rho.genes <- sort(unique(rho.genes))
-    length(rho.genes)
 
     R <- NULL
     ## correlation using external datasets
@@ -658,7 +657,7 @@ pgx.getGeneCorrelation <- function(gene, xref) {
     if(!is.null(R) && NCOL(R)>0) {
         R[is.na(R)] <- 0
         R[is.nan(R)] <- 0
-        if(NCOL(R)==1) R <- matrix(R, ncol=1)
+        # if(NCOL(R)==1) R <- matrix(R, ncol=1)
         rownames(R) <- rho.genes
         R <- R[which(rowSums(R!=0,na.rm=TRUE)>0),,drop=FALSE]
         ## geneset rho has no sign (=cosine correlation) so we use the sign of others


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/481

## Description
From what I have seen, the issue was not related to contrasts being equal, but with the mouse genes only being found in one [external dataset](https://github.com/bigomics/playbase/blob/main/R/pgx-correlation.R#L632-L634). This caused `R` to have only one column. Then, it was converted (I don't know why) to a [matrix](https://github.com/bigomics/playbase/blob/main/R/pgx-correlation.R#L661), which made it loose the column names and [this](https://github.com/bigomics/omicsplayground/blob/master/components/board.correlation/R/correlation_server.R#L208) crashed.

Now, the correlation for that dataset works:

<img width="960" alt="image" src="https://github.com/bigomics/playbase/assets/10220503/8732026f-2600-426e-a948-6f59be59bdd8">
