### PR TITLE
Fix selectSamplesFromSelectedLevels

### DIFF
--- a/R/pgx-functions.R
+++ b/R/pgx-functions.R
@@ -875,24 +875,24 @@ getLevels <- function(Y) {
 }
 
 #' @export
-#' @export
 selectSamplesFromSelectedLevels <- function(Y, levels) {
-  if (is.null(levels) || levels == "") {
+  if (is.null(levels) || all(levels == "")) {
     return(rownames(Y))
   }
-  pheno <- sapply(strsplit(levels, split = "="), "[[", 1)
-  ptype <- sapply(strsplit(levels, split = "="), "[[", 2)
-  sel <- rep(1, nrow(Y))
-  i <- 1
+  pheno <- data.table::tstrsplit(levels, "=", keep = 1) %>%
+    unlist
+  ptype <- data.table::tstrsplit(levels, "=", keep = 2) %>%
+    unlist
+  sel <- rep(FALSE, nrow(Y))
   for (ph in unique(pheno)) {
     k <- which(pheno == ph)
-    sel <- sel * (Y[, ph] %in% ptype[k])
+    sel <- sel | (Y[, ph] %in% ptype[k])
   }
-  rownames(Y)[which(sel == 1)]
+  
+  return(rownames(Y)[which(sel)])
 }
 
 
-#' @export
 #' @export
 getMyGeneInfo <- function(eg, fields = c("symbol", "name", "alias", "map_location", "summary")) {
   info <- lapply(fields, function(f) biomaRt::getGene(eg, fields = f)[[1]])


### PR DESCRIPTION
This commit aims to fix the bug I found in omicsplayground [#563](https://github.com/bigomics/omicsplayground/issues/563). I found that the source of the error was on `selectSamplesFromSelectedLevels`. The old version cannot handle multiple levels, so I focused on that. Moreover, I also fixed the warning from the `if (is.null(levels) || levels == "")` test when dealing with multiple levels. Finally, I did some performance + readability changes for the `stringsplit`.

Something to note, is that selectSamplesFromSelectedLevels appears in multiple scripts of omicsplayground (13 instances in 7 files), so we should be careful this does not break the output somewhere else.

Aside of that, I wrote a unit test code, but I am not sure where to put it. The code is below, but l can also include it myself if indicated where.

```r

testthat::test_that("selectSamplesFromSelectedLevels returns correct samples", {
  
  # Test data
  Y <- data.frame(
    Pheno1 = c("A", "B", "C"),
    Pheno2 = c(1, 2, 3)
  )
  rownames(Y) <- c("sample_1", "sample_2", "sample_3") 
  # Case 1: No levels
  testthat::expect_equal(selectSamplesFromSelectedLevels(Y, levels = NULL), rownames(Y))
  
  # Case 2: Empty levels
  testthat::expect_equal(selectSamplesFromSelectedLevels(Y, levels = ""), rownames(Y)) 
  
  # Case 3: Single level
  levels <- "Pheno1=B"
  testthat::expect_equal(selectSamplesFromSelectedLevels(Y, levels), "sample_2")
  
  # Case 4: Multiple levels  
  levels <- c("Pheno1=A", "Pheno2=3")
  testthat::expect_equal(selectSamplesFromSelectedLevels(Y, levels), c("sample_1", "sample_3"))
  
})

```