### PR TITLE
Improve logic for errors and messages in pgx compute checks

### DIFF
--- a/R/pgx-check.R
+++ b/R/pgx-check.R
@@ -141,7 +141,7 @@ pgx.crosscheckINPUT <- function(
         colnames(counts)
     )
     if (length(SAMPLE_NAMES_NOT_MATCHING_COUNTS) == 0 && PASS) {
-      check_return$e16 <- "Your samples and counts files have no matching rownames and colnames, respectively."
+      check_return$e16 <- "Please correct your samples names in the samples and contrast files."
       pass <- FALSE
     }
 
@@ -174,7 +174,7 @@ pgx.crosscheckINPUT <- function(
     }
 
     if (!MATCH_SAMPLES_COUNTS_ORDER && PASS) {
-      check_return$e18 <- "samples and counts do not have the same order"
+      check_return$e18 <- "We will reorder your samples and counts."
       counts <- counts[, match(rownames(samples), colnames(counts))]
     }
   }

--- a/R/pgx-check.R
+++ b/R/pgx-check.R
@@ -126,6 +126,7 @@ pgx.crosscheckINPUT <- function(
     SAMPLES = NULL,
     COUNTS = NULL,
     CONTRASTS = NULL) {
+      
   samples <- SAMPLES
   counts <- COUNTS
   contrasts <- CONTRASTS
@@ -168,6 +169,11 @@ pgx.crosscheckINPUT <- function(
     # Check that counts have the same order as samples.
 
     MATCH_SAMPLES_COUNTS_ORDER <- all(diff(match(rownames(samples), colnames(counts))) > 0)
+
+    # in case no matches are found, we get an NA, which should be converted to FALSE
+    if (is.na(MATCH_SAMPLES_COUNTS_ORDER)){
+      MATCH_SAMPLES_COUNTS_ORDER <- FALSE
+    }
 
     if (!MATCH_SAMPLES_COUNTS_ORDER && PASS) {
       check_return$e18 <- "samples and counts do not have the same order"

--- a/R/pgx-check.R
+++ b/R/pgx-check.R
@@ -127,23 +127,21 @@ pgx.crosscheckINPUT <- function(
     COUNTS = NULL,
     CONTRASTS = NULL) {
       
-  samples <- SAMPLES
-  counts <- COUNTS
-  contrasts <- CONTRASTS
-  PASS <- TRUE
+    samples <- SAMPLES
+    counts <- COUNTS
+    contrasts <- CONTRASTS
+    PASS <- TRUE
 
-  check_return <- list()
+    check_return <- list()
 
-  if (!is.null(samples) && !is.null(counts)) {
-    # Check that rownames(samples) match colnames(counts)
-    SAMPLE_NAMES_NOT_MATCHING_COUNTS <- intersect(
-      rownames(samples),
-      colnames(counts)
+    if (!is.null(samples) && !is.null(counts)) {
+      # Check that rownames(samples) match colnames(counts)
+      SAMPLE_NAMES_NOT_MATCHING_COUNTS <- intersect(
+        rownames(samples),
+        colnames(counts)
     )
-
-
     if (length(SAMPLE_NAMES_NOT_MATCHING_COUNTS) == 0 && PASS) {
-      check_return$e16 <- SAMPLE_NAMES_NOT_MATCHING_COUNTS
+      check_return$e16 <- "Your samples and counts files have no matching rownames and colnames, respectively."
       pass <- FALSE
     }
 


### PR DESCRIPTION
- e16: Return message in e16 for when samples and counts do not match (zero matches)
- e18: should never be called when there are no matches (due to e16 settings pass to false), but I fixed logic when that happens converting NA to false.

this fixes https://github.com/bigomics/omicsplayground/issues/577