### PR TITLE
Fix #530

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2883,7 +2883,6 @@ pgx.scatterPlotXY.GGPLOT <- function(pos, var = NULL, type = NULL, col = NULL, c
 
     ## determine range for colorbar
     zr <- range(z)
-    # if (!is.null(zlim)) zr <- zlim
     if (zsym && min(zr, na.rm = TRUE) < 0) zr <- c(-1, 1) * max(abs(zr), na.rm = TRUE)
     zz <- round(c(zr[1], zr[2]), digits = 2)
 
@@ -3184,8 +3183,6 @@ pgx.scatterPlotXY.PLOTLY <- function(pos,
       cmin <- -cmax
     }
   }
-
-  ## remove NA??
 
 
   ## ---------------- call PLOTLY -----------


### PR DESCRIPTION
This is in reference to the issue on omics playground #530. 

The zlim were scaling with respect to the data in the each plot, other than respecting a common zlim. 

Setting the zlim manually to the min and max value in the dataframe fixed the issue. 
