### PR TITLE
Cap Fraction > 0.9 doesn't work when there are more than 10% of unidentified genes. 

### DIFF
--- a/R/compute2-extra.R
+++ b/R/compute2-extra.R
@@ -259,8 +259,7 @@ compute_deconvolution <- function(ngs, rna.counts = ngs$counts, full = FALSE) {
 #' @return An updated object with cell cycle and gender inference results.
 #' @export
 compute_cellcycle_gender <- function(ngs, rna.counts = ngs$counts) {
-  pp <- rownames(rna.counts)
-  is.mouse <- (mean(grepl("[a-z]", gsub(".*:|.*\\]", "", pp))) > 0.8)
+  is.mouse <- pgx.getGenetype(rna.counts)
   is.mouse
   if (!is.mouse) {
     message("estimating cell cycle (using Seurat)...")

--- a/R/compute2-extra.R
+++ b/R/compute2-extra.R
@@ -259,7 +259,7 @@ compute_deconvolution <- function(ngs, rna.counts = ngs$counts, full = FALSE) {
 #' @return An updated object with cell cycle and gender inference results.
 #' @export
 compute_cellcycle_gender <- function(ngs, rna.counts = ngs$counts) {
-  is.mouse <- pgx.getGenetype(rna.counts)
+  is.mouse <- pgx.getGenetype(rna.counts)[[1]]
   is.mouse
   if (!is.mouse) {
     message("estimating cell cycle (using Seurat)...")

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -379,11 +379,11 @@ pgx.createPGX <- function(counts, samples, contrasts, X = NULL, ## genes,
   ## -------------------------------------------------------------------
   ## Filter genes?
   ## -------------------------------------------------------------------
-  cap.fraction <- mean(grepl("^[A-Z][a-z]+", rownames(ngs$counts)), na.rm = TRUE)
-  message("[createPGX: filter genes] rownames.ngs.counts = ", head(rownames(ngs$counts)))
-  message("[createPGX: filter genes] cap.frac = ", cap.fraction)
+  filtergenes <- pgx.getGenetype(ngs$counts)
+  message("[createPGX: filter genes] rownames.ngs.counts = ", head(filtergenes[[2]]))
+  message("[createPGX: filter genes] cap.frac = ", filtergenes[[3]])
 
-  is.mouse <- (cap.fraction > 0.9)
+  is.mouse <- filtergenes[[1]]
   org <- ifelse(is.mouse, "mouse", "human")
   message("[createPGX] detected organism: ", org, "")
 

--- a/R/pgx-files.R
+++ b/R/pgx-files.R
@@ -474,7 +474,7 @@ pgx.updateInfoPGX <- function(pgxinfo, pgx, remove.old = TRUE) {
   )
   cond
 
-  is.mouse <- (mean(grepl("[a-z]", pgx$genes$gene_name)) > 0.8)
+  is.mouse <- pgx.getGenetype(pgx$genes)
   organism <- c("human", "mouse")[1 + is.mouse]
   if ("organism" %in% names(pgx)) organism <- pgx$organism
 

--- a/R/pgx-functions.R
+++ b/R/pgx-functions.R
@@ -862,6 +862,15 @@ pgx.getCategoricalPhenotypes <- function(df, min.ncat = 2, max.ncat = 20, remove
   return(colnames(df1))
 }
 
+## Determine if the gene type is mouse 
+#' @export
+pgx.getGenetype <- function(pgx.counts) {
+    rownames.counts <- grep("^rik|^loc|^orf",rownames(pgx.counts),value=TRUE,ignore.case=TRUE,invert=TRUE)
+    cap.fraction <- mean(grepl("^[A-Z][a-z]+", rownames.counts), na.rm = TRUE)
+    is.mouse <- (cap.fraction > 0.8)
+    
+    return(list(is.mouse, cap.fraction, rownames.counts))
+}
 
 
 #' @export


### PR DESCRIPTION
A function that discards the unidentified gene types (LOC, RIK, ORF) when determining the organism. 