### PR TITLE
colors mismatch clustering heatmap

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -4079,7 +4079,6 @@ pgx.splitHeatmapFromMatrix <- function(X, annot, idx = NULL, splitx = NULL,
   if (!is.null(annot)) {
     colors0 <- rep("Set2", ncol(annot))
     names(colors0) <- colnames(annot)
-
     if (!is.null(colors) && any(names(colors) %in% names(colors0))) {
       for (v in intersect(names(colors), names(colors0))) colors0[[v]] <- colors[[v]]
     }
@@ -4194,6 +4193,7 @@ pgx.splitHeatmapFromMatrix <- function(X, annot, idx = NULL, splitx = NULL,
           iheatmapr::add_col_dendro(hc, size = 0.06)
         ## add_col_clustering() %>%
       }
+
       plt <- plt %>%
         iheatmapr::add_col_title(names(xx)[i], side = "top") %>%
         iheatmapr.add_col_annotation(
@@ -4218,9 +4218,9 @@ pgx.splitHeatmapFromMatrix <- function(X, annot, idx = NULL, splitx = NULL,
   ## ----------- row annotation (i.e. gene groups)
   if (!is.null(idx) && !is.null(row_annot_width) && row_annot_width > 0) {
     plt <- iheatmapr::add_row_annotation(
-      plt, data.frame("gene.module" = idx),
+      plt, data.frame("gene.module" = as.factor(idx)), 
       size = row_annot_width * ex,
-      colors = paste0(PLOTLY_COLORS, "88"),
+      colors = list("gene.module" = c(omics_pal_d("muted_light")(nlevels(as.factor(idx))))),
       show_colorbar = show_legend
     )
   }
@@ -4233,7 +4233,6 @@ pgx.splitHeatmapFromMatrix <- function(X, annot, idx = NULL, splitx = NULL,
     gnames <- shortstring(gnames, 25) ## shorten
     gnames <- sub("   ", "-", gnames)
 
-
     maxlen <- max(sapply(gnames, nchar))
     w <- ifelse(maxlen >= 20, 0.45, 0.20)
     s1 <- ifelse(maxlen >= 20, 9, 11) * rowcex
@@ -4243,7 +4242,6 @@ pgx.splitHeatmapFromMatrix <- function(X, annot, idx = NULL, splitx = NULL,
       size = w * ex, font = list(size = s1)
     )
   }
-
 
   return(plt)
 }


### PR DESCRIPTION
Colors of the cluster label was not matching across the board because different color palettes were being used at each cards. 

Including that, iheatmapr::add_row_annotation factors the input annotation and sets colors automatically. 

Factoring the input annotation beforehand, leaves us the choice to apply custom coloring. Documentation of colors option in iheatmapr::add_row_annotation is not clear. 
It says (list of color palettes, with one color per annotation column name) and nothing about the factors. 

More clear explanation is given on this issue 