### PR TITLE
Improve logic of sample level selection (selectSamplesFromSelectedLevels )

### DIFF
--- a/R/pgx-functions.R
+++ b/R/pgx-functions.R
@@ -1198,13 +1198,18 @@ selectSamplesFromSelectedLevels <- function(Y, levels) {
   if (is.null(levels) || all(levels == "")) {
     return(rownames(Y))
   }
+  
+  # fill ="" will (unfortunately) still return NA when level is "NA"... which crashes when phenotype is ""
   pheno <- data.table::tstrsplit(levels, "=", keep = 1) %>%
     unlist()
   ptype <- data.table::tstrsplit(levels, "=", keep = 2) %>%
     unlist()
+  # force replace "NA" by NA
+  ptype[ptype == "NA"] <- NA
   ##  sel <- rep(FALSE, nrow(Y))
   sel <- rep(TRUE, nrow(Y))
   for (ph in unique(pheno)) {
+    #ph = pheno[1]
     k <- which(pheno == ph)
     ##    sel <- sel | (Y[, ph] %in% ptype[k])
     sel <- sel & (Y[, ph] %in% ptype[k])


### PR DESCRIPTION
This pull request fixes an issue in the selectSamplesFromSelectedLevels function where the function crashes when the level is "NA". The fix involves replacing "NA" with NA in the ptype variable.

@ivokwee fixed logix in the master branch