### PR TITLE
v3.3: Fix handling of floating values in contrast matrix (float design matrix)

### DIFF
--- a/R/pgx-contrasts.R
+++ b/R/pgx-contrasts.R
@@ -725,6 +725,12 @@ contrastAsLabels <- function(contr.matrix, as.factor = FALSE) {
     x
   }
   num.values <- c(-1, 0, 1, NA, "NA", "na", "", " ")
+
+  # convert values <0 to 1 and values >0 to 1 (necessary for some old design matrix with float values)
+  # sign function will fail when non-numeric values are present, use try catch to preserve input
+
+  contr.matrix <- tryCatch(sign(contr.matrix), error = function(e) contr.matrix)
+
   is.num <- all(apply(contr.matrix, 2, function(x) all(x %in% num.values)))
   is.num
   if (!is.num) {


### PR DESCRIPTION
**solution:** contrastAsLabels function was not identifying float design matrix as a contrast matrix, and not converting to labes. This is fixed by transforming the floating values with the sign function.

data:
[exp-matrix.csv](https://github.com/bigomics/playbase/files/13963485/exp-matrix.csv)

before fix:
![image](https://github.com/bigomics/playbase/assets/28757711/0b1a2636-2ce9-414d-9a4e-06b839b6d8bc)


after fix: 

![image](https://github.com/bigomics/playbase/assets/28757711/c4c4d302-a1c9-4013-9727-7324aa962754)


this fixes https://github.com/bigomics/omicsplayground/issues/840