### PR TITLE
Fix filtering on genesets in pgx.add_GMT function

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -843,7 +843,7 @@ pgx.add_GMT <- function(pgx, custom.geneset = NULL, max.genesets = 20000) {
   ## -----------------------------------------------------------
 
   message("[pgx.add_GMT] Filtering gene sets on size...")
-  gmt.size <- Matrix::rowSums(G != 0)
+  gmt.size <- Matrix::colSums(G != 0)
   size.ok <- which(gmt.size >= 15 & gmt.size <= 400)
   G <- G[, size.ok, drop = FALSE]
 


### PR DESCRIPTION
**Problem:** 

50x less genesets that we should have for example data, issue https://github.com/bigomics/omicsplayground/issues/862



**Description:**

This pull request fixes a bug in the pgx.add_GMT function where the filtering on genesets was incorrectly done using rowSums instead of colSums. This PR corrects the filtering to use colSums, ensuring that the appropriate geneset collection is obtained.


**Result:**

![image](https://github.com/bigomics/playbase/assets/28757711/9fb617f9-5923-4319-85e7-d322b4479e4d)

