### PR TITLE
Update threshold for probe_type in guess_probetype function

### DIFF
--- a/R/pgx-ensembl.R
+++ b/R/pgx-ensembl.R
@@ -411,7 +411,7 @@ guess_probetype <- function(probes, organism = "", for.biomart = FALSE) {
     symbol <- as.list(org.Hs.eg.db::org.Hs.egSYMBOL)
     avg.match <- mean(toupper(probes) %in% symbol)
     avg.match
-    if (avg.match > 0.5) probe_type <- "SYMBOL"
+    if (avg.match > 0.3) probe_type <- "SYMBOL"
   }
 
   ## 3. check if they are proteins


### PR DESCRIPTION
**Problem:** 

Hard 50% threshold of symbols matching rownames(counts) to accept the probe type as symbol caused failure, see https://github.com/bigomics/omicsplayground/issues/864, as some datasets have <0.5% symbol matches.

``` R
Error in ngs.getGeneAnnotation(pgx = pgx, probes = probes, annot_table = annot_table,  : 
  probe_type is NULL
Calls: <Anonymous> -> pgx.addGeneAnnotation -> ngs.getGeneAnnotation
In addition: Warning messages:
1: replacing previous import ‘data.table::last’ by ‘dplyr::last’ when loading ‘playbase’ 
2: replacing previous import ‘data.table::first’ by ‘dplyr::first’ when loading ‘playbase’ 
3: replacing previous import ‘data.table::between’ by ‘dplyr::between’ when loading ‘playbase’ 
4: replacing previous import ‘data.table::transpose’ by ‘purrr::transpose’ when loading ‘playbase’ 
5: In guess_probetype(probes, for.biomart = FALSE) :
  [guess_probetype] ERROR : unsupported probe_type: 
6: In guess_probetype(probes, for.biomart = FALSE) :
  [guess_probetype] keytypes available: ENSEMBL ENSEMBLPROT ENSEMBLTRANS ENTREZID REFSEQ SYMBOL UNIPROT
Execution halted
```

**Solution:** 

Reduce the threshold for the average match in the guess_probetype function from 0.5 to 0.3. This will result in fewer matches triggering the symbol as the probe type.

After fix:
<img width="386" alt="image" src="https://github.com/bigomics/playbase/assets/28757711/a41c7baa-738b-4eb6-97dc-89599f97a316">

**Possible developments:**

- Move `guess_probetype` function to the upload module instead of compute module, so users can get these warnings earlier.
- Refactor `guess_probetype` so it iterates across more probe types and picks the best match

@ivokwee let me know if we should open tickets for any of the above!
