### PR TITLE
Fix data frame conversion in pgx.createPGX function that introduced a drop phenotype

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -185,7 +185,7 @@ pgx.createPGX <- function(counts,
   ## -------------------------------------------------------------------
   ## clean up input files
   ## -------------------------------------------------------------------
-  samples <- data.frame(samples, drop = FALSE)
+  samples <- as.data.frame(samples, drop = FALSE)
   counts <- as.matrix(counts)
   if (is.null(contrasts)) contrasts <- samples[, 0]
 


### PR DESCRIPTION
This pull request fixes an issue in the pgx.createPGX function where the data frame "drop = FALSE" was incorrectly assigned as a variable. The fix ensures that the conversion is done correctly using the as.data.frame function.

This fixes https://github.com/bigomics/omicsplayground/issues/864