### PR TITLE
fix: edge case not only trace length is equal to X

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -4454,10 +4454,11 @@ plotly_build_light <- function(
           attrs_length <- purrr::map_int(trace_eval, length)
 
           vars_long <- names(trace_eval[attrs_length == attrs_length["x"]])
+          vars_long <- intersect(vars_long, vars_hf)
 
           data_long <- trace_eval[vars_long] %>%
             data.table::setDT() %>%
-            .[, lapply(.SD, list), by = setdiff(vars_long, vars_hf)]
+            .[, lapply(.SD, list)]
 
           trace_data <- purrr::pmap(
             data_long,


### PR DESCRIPTION
This line https://github.com/bigomics/playbase/compare/fix-%23872?expand=1#diff-160245acbb61e1773d34566d004a348e15ead57c731f5d2ae8420537bdaf9c0eR4456 assumes that all the vars with the same length as X are the trace, for every plot there is a single case where this is not true (miraculously found by issue https://github.com/bigomics/omicsplayground/issues/872). It's easier to just intersect with the hf vars, also that can be controlled as an input, giving easier implementation on different plots.

This closes https://github.com/bigomics/omicsplayground/issues/872