### PR TITLE
Remove unnecessary guess_organism check and dbg

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -328,8 +328,6 @@ pgx.createPGX <- function(counts,
   ## -------------------------------------------------------------------
   message("[createPGX] creating pgx object...")
 
-  browser()
-
   ## remove special characters from description (other columns too??)
   description <- gsub("[\"\']", " ", description) ## remove quotes (important!!)
   description <- gsub("[\n]", ". ", description) ## replace newline

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -182,6 +182,11 @@ pgx.createPGX <- function(counts,
     stop("rownames of counts and X do not match\n")
   }
 
+  # return if organism is null
+  if (is.null(organism)) {
+    stop("[createPGX] FATAL: organism is NULL")
+  }
+
   ## -------------------------------------------------------------------
   ## clean up input files
   ## -------------------------------------------------------------------
@@ -322,18 +327,8 @@ pgx.createPGX <- function(counts,
   ## create pgx object
   ## -------------------------------------------------------------------
   message("[createPGX] creating pgx object...")
-  guess_organism <- guess_organism(rownames(counts))
-  if (is.null(organism)) {
-    organism <- guess_organism
-  }
-  if (!is.null(organism) && !is.null(guess_organism)) {
-    if (tolower(organism) != tolower(guess_organism)) {
-      warning(
-        "[createPGX] WARNING : guessed organism is '", guess_organism,
-        "' but '", organism, "' was provided!"
-      )
-    }
-  }
+
+  browser()
 
   ## remove special characters from description (other columns too??)
   description <- gsub("[\"\']", " ", description) ## remove quotes (important!!)


### PR DESCRIPTION
**Requires new upload, where choosing organism is mandatory. In old upload, that step can be skipped sometimes.** 

This pull request removes the unnecessary guess_organism check from the code. It also adds a check for a null organism and throws an error if it is null, as organism should never be null.

This fixes the issue where guess_organism was returning two organisms (rat, mouse) when probes were very similar (30% threshold), and crashing computation.

```r
[createPGX] creating pgx object...
[guess_organism] auto-detected organism = MouseRat
Error in if (tolower(organism) != tolower(guess_organism)) { : 
  the condition has length > 1
```

