### PR TITLE
fix: sample all file to obtain decimal point character

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -118,7 +118,7 @@ detect_delim <- function(file) {
 #' a header and rownames column.
 #'
 detect_decimal <- function(file) {
-  ff <- data.table::fread(file, nrows = 10, header = TRUE, colClasses = "character")
+  ff <- data.table::fread(file, header = TRUE, colClasses = "character")
   vals <- as.vector(as.matrix(ff[, -1]))
   n_commas <- length(grep(",", vals, fixed = TRUE))
   n_dots <- length(grep(".", vals, fixed = TRUE))


### PR DESCRIPTION
We were just sampling the first 10 rows of the file in order to obtain the decimal point character. This generally is fine, however, we have received customer failed datasets which failed because the first rows were 0s, therefore, this funcion did not correctly detect the decimal point character.

Even though sampling the whole file adds a slight overhead to the dataset compute, it is orders of magnitude lower than the whole computation itself: association methods, etc. So I think it is worth it making 100% sure we get this information right in favour of not failing to compute.