### PR TITLE
CRITICAL: Remove artifacts from xbioc probe type results

### DIFF
--- a/R/pgx-ensembl.R
+++ b/R/pgx-ensembl.R
@@ -743,8 +743,15 @@ detect_probetype.MATCH <- function(probes, organism = "", for.biomart = FALSE) {
 
   ## 2. determine probe type using regular expression
   if (probe_type == "") {
-    ## probe_type <- xbioc::idtype(probes)
-    idtype.table <- table(sapply(head(sample(probes), 1000), xbioc::idtype))
+    
+    idtype.table <- sapply(head(sample(probes), 1000), xbioc::idtype)
+
+    # remove empty columns and ".nuID" from idtypetable
+    idtype.table <- gsub(".nuID", NA, idtype.table)
+    idtype.table <- idtype.table[which(idtype.table != "")]
+
+    idtype.table <- table(idtype.table)
+
     probe_type <- names(which.max(idtype.table))
   }
 


### PR DESCRIPTION
This pull request removes artifacts from the xbioc probe type results. The changes include removing empty columns and ".nuID" from the idtypetable.

### before
```r
Browse[1]> idtype.table

            .nuID GENEBANK 
     856       37      107 
Browse[1]> names(which.max(idtype.table))
[1] ""
```
table returned "" as a valid probe type, as it had 856 matches compared to 107 for GENEBANK. 

### after fix

```r
Browse[2]>     idtype.table <- gsub(".nuID", NA, idtype.table)
Browse[2]>     idtype.table <- idtype.table[which(idtype.table != "")]
Browse[2]> 
debug: probe_type <- best.match(type.regex, 0.33)
Browse[2]>     idtype.table <- table(idtype.table)
Browse[2]> names(which.max(idtype.table))
[1] "GENEBANK"
```

GENEBANK is then converted to UNIPROT, which gives correct proba type.