### PR TITLE
Fix as.matrix conversion issue with integer64

### DIFF
--- a/R/pgx-check.R
+++ b/R/pgx-check.R
@@ -8,8 +8,9 @@
 #' @return a list with two elements: `checks` which contains the status of the checks, and
 #'  `PASS` which contains the overall status of the check.
 #' @export
-pgx.checkINPUT <- function(df,
-                           type = c("SAMPLES", "COUNTS", "EXPRESSION", "CONTRASTS")) {
+pgx.checkINPUT <- function(
+    df,
+    type = c("SAMPLES", "COUNTS", "EXPRESSION", "CONTRASTS")) {
   datatype <- match.arg(type)
   df_clean <- df
   PASS <- TRUE

--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -54,8 +54,16 @@ read.as_matrix <- function(file, skip_row_check = FALSE) {
     ## rownames. as.matrix means we do not have mixed types (such as in
     ## dataframes).
     if (ncol(x0) >= 2) {
-      x <- as.matrix(x0[sel, -1, drop = FALSE]) ## always as matrix
+      x <- x0[sel, -1, drop = FALSE]
+      # convert x from data.table to matrix. This is needed as fread reads numeric as integer64, which is not supported by matrix
+      # at this stage since we handle samples, counts and contrasts, it is dangerous to force conversion to numeric
+      # hence, the conversion from character to numeric for counts is handled at pgx.checkINPUT
+      colnames_x <- colnames(x)
+      x <- sapply(1:ncol(x), function(i) {
+        as.character(x[[i]])
+      })
       rownames(x) <- x0[[1]][sel]
+      colnames(x) <- colnames_x
     } else {
       x <- matrix(NA, length(sel), 0)
       rownames(x) <- x0[[1]][sel]


### PR DESCRIPTION
**this fixes https://github.com/bigomics/omicsplayground/issues/971**

This pull request fixes an issue where the `as.matrix` function was converting integer64 values to strange values. The problem was that the type was not handled correctly in the matrix. The fix ensures that the conversion from data.table to matrix is done properly, preserving the correct types.