### PR TITLE
Reduce RAM footprint

### DIFF
--- a/R/gset-meta.r
+++ b/R/gset-meta.r
@@ -119,6 +119,7 @@ gset.fitContrastsWithAllMethods <- function(gmt,
     message("fitting contrasts using GSVA/limma... ")
 
     ## check if we have the new version of GSVA
+    browser()
     new.gsva <- exists("gsvaParam", where = asNamespace("GSVA"), mode = "function")
     new.gsva
     tt <- system.time({
@@ -130,7 +131,7 @@ gset.fitContrastsWithAllMethods <- function(gmt,
         })
       } else {
         zx.gsva <- try({
-          GSVA::gsva(as.matrix(X), gmt, method = "gsva", parallel.sz = mc.cores, verbose = FALSE)
+          GSVA::gsva(as.matrix(X), gmt, method = "gsva", parallel.sz = 1, verbose = FALSE)
         })
       }
 

--- a/R/gset-meta.r
+++ b/R/gset-meta.r
@@ -39,9 +39,8 @@ gset.fitContrastsWithAllMethods <- function(gmt,
   timings <- c()
 
   if (is.null(mc.cores)) {
-    mc.cores <- round(0.25 * parallel::detectCores(all.tests = TRUE, logical = FALSE)) ## max 25% of cores
-    mc.cores <- pmax(mc.cores, 1) ## min 1 core
-    mc.cores <- pmin(mc.cores, 16) ## max 16 cores
+    # Multi-thread on gsva makes RAM usage go up (crashing computations) and in most cases it's slower due to overheads
+    mc.cores <- 1
   }
   message("using ", mc.cores, " number of cores")
   message("using ", mc.threads, " number of threads")
@@ -130,18 +129,8 @@ gset.fitContrastsWithAllMethods <- function(gmt,
         })
       } else {
         zx.gsva <- try({
-          GSVA::gsva(as.matrix(X), gmt, method = "gsva", parallel.sz = 1, verbose = FALSE)
+          GSVA::gsva(as.matrix(X), gmt, method = "gsva", parallel.sz = mc.cores, verbose = FALSE)
         })
-      }
-
-      if (is.null(zx.gsva) || "try-error" %in% class(zx.gsva)) {
-        ## switch to single core...
-        warning("WARNING: GSVA ERROR: retrying single core... ")
-        if (new.gsva) {
-          zx.gsva <- try(GSVA::gsva(GSVA::gsvaParam(as.matrix(X), gmt)))
-        } else {
-          zx.gsva <- try(GSVA::gsva(as.matrix(X), gmt, method = "gsva", parallel.sz = 1, verbose = FALSE))
-        }
       }
 
       if (!"try-error" %in% class(zx.gsva)) {

--- a/R/gset-meta.r
+++ b/R/gset-meta.r
@@ -119,7 +119,6 @@ gset.fitContrastsWithAllMethods <- function(gmt,
     message("fitting contrasts using GSVA/limma... ")
 
     ## check if we have the new version of GSVA
-    browser()
     new.gsva <- exists("gsvaParam", where = asNamespace("GSVA"), mode = "function")
     new.gsva
     tt <- system.time({

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -178,7 +178,7 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, R1[, i], nPermSimple = 10000))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -129,8 +129,8 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
     fx <- apply(FC[gg, , drop = FALSE], 2, rank)
     R1 <- qlcMatrix::corSparse(X[gg, ], fx)
   } else {
-    rnk1 <- apply(X[gg, , drop = FALSE], 2, rank, na.last = "keep")
-    rnk2 <- apply(FC[gg, , drop = FALSE], 2, rank, na.last = "keep")
+    rnk1 <- t(matrixStats::colRanks(X[gg, , drop = FALSE], ties.method = "average", na.last = "keep"))
+    rnk2 <- t(matrixStats::colRanks(FC[gg, , drop = FALSE], ties.method = "average", na.last = "keep"))
     system.time(R1 <- stats::cor(rnk1, rnk2, use = "pairwise"))
   }
   R1 <- as.matrix(R1)

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -178,7 +178,7 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, R1[, i], nPermSimple = 10000))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -173,12 +173,13 @@ message(">>> [pgx-drugs] point 11")
   }
 
   if ("GSEA" %in% methods) {
+    bpparam <- BiocParallel::MulticoreParam(1)
     message("Calculating drug enrichment using GSEA ...")
     res0 <- list()
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i]))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -179,7 +179,8 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
+      # suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000 BPPARAM = bpparam))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -179,8 +179,7 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      # suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
-      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000 BPPARAM = bpparam))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -69,8 +69,8 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   ## 'obj'   : can be ngs object or fold-change matrix
   ## X       : drugs profiles (may have multiple for one drug)
   ## xdrugs  : drug associated with profile
-  if (is.null(X)) {
 
+  if (is.null(X)) {
     X <- playdata::L1000_ACTIVITYS_N20D1011
     dim(X)
   }
@@ -139,7 +139,7 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   R1 <- R1 + 1e-8 * matrix(stats::rnorm(length(R1)), nrow(R1), ncol(R1))
   colnames(R1) <- colnames(FC)
   rownames(R1) <- colnames(X)
-  
+
   ## experiment to drug
   results <- list()
   if ("cor" %in% methods) {

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -178,7 +178,7 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], nPermSimple = 10000))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -70,6 +70,7 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   ## X       : drugs profiles (may have multiple for one drug)
   ## xdrugs  : drug associated with profile
   if (is.null(X)) {
+
     X <- playdata::L1000_ACTIVITYS_N20D1011
     dim(X)
   }
@@ -95,6 +96,7 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
     contrast <- colnames(FC)
   }
   contrast <- intersect(contrast, colnames(FC))
+
   FC <- FC[, contrast, drop = FALSE]
 
   if (!obj$organism %in% c("Human", "human")) {
@@ -104,9 +106,11 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
     )
     rownames(FC) <- human_genes
   }
+
   ## create drug meta sets
   meta.gmt <- tapply(colnames(X), xdrugs, list)
   meta.gmt <- meta.gmt[which(sapply(meta.gmt, length) >= nmin)]
+
   if (length(meta.gmt) == 0) {
     message("WARNING::: pgx.computeDrugEnrichment : no valid genesets!!")
     return(NULL)
@@ -115,6 +119,7 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   ## first level (rank) correlation
   message("Calculating first level rank correlation ...")
   gg <- intersect(rownames(X), rownames(FC))
+
   if (length(gg) < 20) {
     message("WARNING::: pgx.computeDrugEnrichment : not enough common genes!!")
     return(NULL)
@@ -134,6 +139,7 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   R1 <- R1 + 1e-8 * matrix(stats::rnorm(length(R1)), nrow(R1), ncol(R1))
   colnames(R1) <- colnames(FC)
   rownames(R1) <- colnames(X)
+  
   ## experiment to drug
   results <- list()
   if ("cor" %in% methods) {
@@ -207,12 +213,10 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
       results[[k]]$Q <- res$Q[mtop, , drop = FALSE]
       results[[k]]$size <- res$size[mtop]
     }
-    message(">>> [pgx-drugs] point 26")
   }
 
   ## reduce large stats object
   sel.drugs <- unique(unlist(sapply(results, function(res) rownames(res$X))))
-  message(">>> [pgx-drugs] point 27")
   sel <- which(xdrugs %in% sel.drugs)
   results$stats <- R1[sel, , drop = FALSE]
 

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -178,7 +178,7 @@ message(">>> [pgx-drugs] point 11")
     i <- 1
     message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], nPermSimple = 10000))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i]))
     }
     names(res0) <- colnames(R1)
     message(">>> [pgx-drugs] point 23")

--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -69,29 +69,23 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   ## 'obj'   : can be ngs object or fold-change matrix
   ## X       : drugs profiles (may have multiple for one drug)
   ## xdrugs  : drug associated with profile
-  message(">>> [pgx-drugs] point 1")
   if (is.null(X)) {
     X <- playdata::L1000_ACTIVITYS_N20D1011
     dim(X)
   }
-  message(">>> [pgx-drugs] point 2")
 
   if ("gx.meta" %in% names(obj)) {
-    message(">>> [pgx-drugs] point 3")
     FC <- pgx.getMetaMatrix(obj)$fc
-    message(">>> [pgx-drugs] point 4")
     ## check if multi-omics
     is.multiomics <- any(grepl("\\[gx\\]|\\[mrna\\]", rownames(FC)))
     if (is.multiomics) {
       jj <- grep("\\[gx\\]|\\[mrna\\]", rownames(FC))
       FC <- FC[jj, , drop = FALSE]
     }
-    message(">>> [pgx-drugs] point 5")
     rownames(FC) <- toupper(sub(".*:|.*\\]", "", rownames(FC)))
 
     FC <- FC[order(-rowMeans(FC**2)), , drop = FALSE]
     FC <- FC[!duplicated(rownames(FC)), , drop = FALSE]
-    message(">>> [pgx-drugs] point 6")
   } else {
     ## it is a matrix
     FC <- obj
@@ -101,7 +95,6 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
     contrast <- colnames(FC)
   }
   contrast <- intersect(contrast, colnames(FC))
-  message(">>> [pgx-drugs] point 7")
   FC <- FC[, contrast, drop = FALSE]
 
   if (!obj$organism %in% c("Human", "human")) {
@@ -109,14 +102,11 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
       obj$genes$human_ortholog,
       obj$genes$symbol
     )
-    message(">>> [pgx-drugs] point 8")
     rownames(FC) <- human_genes
   }
-message(">>> [pgx-drugs] point 9")
   ## create drug meta sets
   meta.gmt <- tapply(colnames(X), xdrugs, list)
   meta.gmt <- meta.gmt[which(sapply(meta.gmt, length) >= nmin)]
-message(">>> [pgx-drugs] point 10")
   if (length(meta.gmt) == 0) {
     message("WARNING::: pgx.computeDrugEnrichment : no valid genesets!!")
     return(NULL)
@@ -125,50 +115,39 @@ message(">>> [pgx-drugs] point 10")
   ## first level (rank) correlation
   message("Calculating first level rank correlation ...")
   gg <- intersect(rownames(X), rownames(FC))
-message(">>> [pgx-drugs] point 11")
   if (length(gg) < 20) {
     message("WARNING::: pgx.computeDrugEnrichment : not enough common genes!!")
     return(NULL)
   }
   if (any(class(X) == "dgCMatrix")) {
-    message(">>> [pgx-drugs] point 12")
     ## gene set enrichment by rank correlation
     fx <- apply(FC[gg, , drop = FALSE], 2, rank)
     R1 <- qlcMatrix::corSparse(X[gg, ], fx)
   } else {
-    message(">>> [pgx-drugs] point 13")
     rnk1 <- t(matrixStats::colRanks(X[gg, , drop = FALSE], ties.method = "average", na.last = "keep"))
     rnk2 <- t(matrixStats::colRanks(FC[gg, , drop = FALSE], ties.method = "average", na.last = "keep"))
     system.time(R1 <- stats::cor(rnk1, rnk2, use = "pairwise"))
   }
-  message(">>> [pgx-drugs] point 14")
   R1 <- as.matrix(R1)
   R1[is.nan(R1)] <- 0
   R1[is.infinite(R1)] <- 0
-  message(">>> [pgx-drugs] point 15")
   R1 <- R1 + 1e-8 * matrix(stats::rnorm(length(R1)), nrow(R1), ncol(R1))
   colnames(R1) <- colnames(FC)
   rownames(R1) <- colnames(X)
-  message(">>> [pgx-drugs] point 16")
   ## experiment to drug
   results <- list()
   if ("cor" %in% methods) {
     message("Calculating drug enrichment using rank correlation ...")
     D <- Matrix::sparse.model.matrix(~ 0 + xdrugs)
-    message(">>> [pgx-drugs] point 17")
     colnames(D) <- sub("^xdrugs", "", colnames(D))
     rownames(D) <- colnames(X) ## not necessary..
     rho2 <- qlcMatrix::corSparse(D, R1)
-    message(">>> [pgx-drugs] point 18")
     rownames(rho2) <- colnames(D)
     colnames(rho2) <- colnames(R1)
     rho2 <- rho2[order(-rowMeans(rho2**2)), , drop = FALSE]
-    message(">>> [pgx-drugs] point 19")
     .cor.pvalue <- function(x, n) 2 * stats::pnorm(-abs(x / ((1 - x**2) / (n - 2))**0.5))
     P <- apply(rho2, 2, .cor.pvalue, n = nrow(D))
-    message(">>> [pgx-drugs] point 20")
     Q <- apply(P, 2, stats::p.adjust, method = "fdr")
-    message(">>> [pgx-drugs] point 21")
     results[["cor"]] <- list(X = rho2, Q = Q, P = P)
   }
 
@@ -177,18 +156,14 @@ message(">>> [pgx-drugs] point 11")
     message("Calculating drug enrichment using GSEA ...")
     res0 <- list()
     i <- 1
-    message(">>> [pgx-drugs] point 22")
     for (i in 1:ncol(R1)) {
-      # suppressWarnings(res0[[i]] <- fgsea::fgseaMultilevel(meta.gmt, stats = R1[, i], BPPARAM = bpparam))
-      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000 BPPARAM = bpparam))
+      suppressWarnings(res0[[i]] <- fgsea::fgseaSimple(meta.gmt, stats = R1[, i], nperm = 10000, BPPARAM = bpparam))
     }
     names(res0) <- colnames(R1)
-    message(">>> [pgx-drugs] point 23")
 
     mNES <- sapply(res0, function(x) x$NES)
     mQ <- sapply(res0, function(x) x$padj)
     mP <- sapply(res0, function(x) x$pval)
-    message(">>> [pgx-drugs] point 24")
     if (length(res0) == 1) {
       mNES <- cbind(mNES)
       mP <- cbind(mP)
@@ -199,7 +174,6 @@ message(">>> [pgx-drugs] point 11")
     rownames(mNES) <- rownames(mQ) <- rownames(mP) <- pw
     colnames(mNES) <- colnames(mQ) <- colnames(mP) <- colnames(FC)
     msize <- res0[[1]]$size
-    message(">>> [pgx-drugs] point 25")
     results[["GSEA"]] <- list(X = mNES, Q = mQ, P = mP, size = msize)
   }
 

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -125,6 +125,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   cn <- rhdf5::h5read(h5.file, "data/colnames")
   gg <- intersect(names(fc), rn)
   fc <- fc[gg]
+
   ## --------------------------------------------------
   ## get top100 signatures
   ## --------------------------------------------------
@@ -142,9 +143,6 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## Test signatures using fGSEA (this is pretty fast. amazing.)
   ## ------------------------------------------------------------
   ## combine up/down into one (unsigned GSEA test)
-  # split_list <- function(input_list, chunk_size) {
-  #   split(input_list, ceiling(seq_along(input_list)/chunk_size))
-  # }
   system.time({
     gmt <- rbind(sig100.up, sig100.dn)
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)
@@ -152,9 +150,9 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos", BPPARAM = bpparam)
   })
 
-  # res$ES <- NULL
-  # res$leadingEdge <- NULL
-  # res$pval <- NULL
+  res$ES <- NULL
+  res$leadingEdge <- NULL
+  res$pval <- NULL
 
   ## --------------------------------------------------
   ## select ntop best
@@ -236,6 +234,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   jj <- match(res$pathway, names(rho))
   res$rho <- rho[jj]
   res$R2 <- rho[jj]**2
+
   ii <- match(res$pathway, rownames(stats))
   res$odd.ratio <- stats$odd.ratio[ii]
   res$overlap <- stats$overlap[ii]
@@ -470,7 +469,7 @@ pgx.addEnrichmentSignaturesH5 <- function(h5.file, X = NULL, mc.cores = 0,
 
       xi <- xi + 1e-3 * stats::rnorm(length(xi))
       suppressMessages(suppressWarnings(
-        res1 <- fgsea::fgseaMultilevel(gmt, xi, nPermSimple = 10000, nproc = mc.cores)
+        res1 <- fgsea::fgseaSimple(gmt, xi, nperm = 10000, nproc = 1)
       ))
       r <- res1$NES
       names(r) <- res1$pathway

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -154,18 +154,18 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     names(gmt) <- colnames(sig100.up)
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
-      # gmt_blocks <- split_list(gmt, 5000)
-      # results_list <- list()
-      # for (i in seq_along(gmt_blocks)) {
-      #   block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), nPermSimple = nperm, scoreType = "pos")
-      #   block_result$ES <- NULL
-      #   block_result$leadingEdge <- NULL
-      #   block_result$pval <- NULL
-      #   results_list[[i]] <- block_result
-      # }
-      # res <- do.call(rbind, results_list)
+      gmt_blocks <- split_list(gmt, 5000)
+      results_list <- list()
+      for (i in seq_along(gmt_blocks)) {
+        block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos")
+        block_result$ES <- NULL
+        block_result$leadingEdge <- NULL
+        block_result$pval <- NULL
+        results_list[[i]] <- block_result
+      }
+      res <- do.call(rbind, results_list)
 
-      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
+      # res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -145,27 +145,27 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## Test signatures using fGSEA (this is pretty fast. amazing.)
   ## ------------------------------------------------------------
   ## combine up/down into one (unsigned GSEA test)
-  split_list <- function(input_list, chunk_size) {
-    split(input_list, ceiling(seq_along(input_list)/chunk_size))
-  }
+  # split_list <- function(input_list, chunk_size) {
+  #   split(input_list, ceiling(seq_along(input_list)/chunk_size))
+  # }
   system.time({
     gmt <- rbind(sig100.up, sig100.dn)
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)
     names(gmt) <- colnames(sig100.up)
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
-      gmt_blocks <- split_list(gmt, 5000)
-      results_list <- list()
-      for (i in seq_along(gmt_blocks)) {
-        block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), nPermSimple = nperm, scoreType = "pos")
-        block_result$ES <- NULL
-        block_result$leadingEdge <- NULL
-        block_result$pval <- NULL
-        results_list[[i]] <- block_result
-      }
-      res <- do.call(rbind, results_list)
+      # gmt_blocks <- split_list(gmt, 5000)
+      # results_list <- list()
+      # for (i in seq_along(gmt_blocks)) {
+      #   block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), nPermSimple = nperm, scoreType = "pos")
+      #   block_result$ES <- NULL
+      #   block_result$leadingEdge <- NULL
+      #   block_result$pval <- NULL
+      #   results_list[[i]] <- block_result
+      # }
+      # res <- do.call(rbind, results_list)
 
-      # res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
+      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -114,6 +114,7 @@ pgx.computeConnectivityScores <- function(pgx, sigdb, ntop = 200, contrasts = NU
 #' @export
 pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm = 10000) {
   if (is.null(names(fc))) stop("fc must have names")
+  browser()
   ## mouse... mouse...
   names(fc) <- toupper(names(fc))
 
@@ -146,11 +147,11 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)
     names(gmt) <- colnames(sig100.up)
     suppressMessages(suppressWarnings(
-      res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos")
+      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
+      # https://github.com/ctlab/fgsea/issues/103
     )) ## really unsigned???
   })
 
-  res$nMoreExtreme <- NULL
   res$ES <- NULL
   res$leadingEdge <- NULL
   res$pval <- NULL

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -501,7 +501,7 @@ pgx.addEnrichmentSignaturesH5 <- function(h5.file, X = NULL, mc.cores = 0,
 
       xi <- xi + 1e-3 * stats::rnorm(length(xi))
       suppressMessages(suppressWarnings(
-        res1 <- fgsea::fgseaSimple(gmt, xi, nperm = 10000, nproc = mc.cores)
+        res1 <- fgsea::fgseaMultilevel(gmt, xi, nPermSimple = 10000, nproc = mc.cores)
       ))
       r <- res1$NES
       names(r) <- res1$pathway

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -165,7 +165,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
       # }
       # res <- do.call(rbind, results_list)
 
-      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
+      res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos")
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -167,8 +167,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
       # }
       # res <- do.call(rbind, results_list)
 
-      # res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos", BPPARAM = bpparam)
-      res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos", BPPARAM = bpparam)
+      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos", BPPARAM = bpparam)
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -165,7 +165,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
       # }
       # res <- do.call(rbind, results_list)
 
-      res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos")
+      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -145,9 +145,9 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## Test signatures using fGSEA (this is pretty fast. amazing.)
   ## ------------------------------------------------------------
   ## combine up/down into one (unsigned GSEA test)
-  # split_list <- function(input_list, chunk_size) {
-  #   split(input_list, ceiling(seq_along(input_list)/chunk_size))
-  # }
+  split_list <- function(input_list, chunk_size) {
+    split(input_list, ceiling(seq_along(input_list)/chunk_size))
+  }
   system.time({
     gmt <- rbind(sig100.up, sig100.dn)
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -116,6 +116,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   if (is.null(names(fc))) stop("fc must have names")
   ## mouse... mouse...
   names(fc) <- toupper(names(fc))
+  dbg(">>> [pgx-sign] point 1")
 
   ## or instead compute correlation on top100 fc genes (read from file)
   rhdf5::h5closeAll()
@@ -123,7 +124,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   cn <- rhdf5::h5read(h5.file, "data/colnames")
   gg <- intersect(names(fc), rn)
   fc <- fc[gg]
-
+  dbg(">>> [pgx-sign] point 2")
   ## --------------------------------------------------
   ## get top100 signatures
   ## --------------------------------------------------
@@ -131,9 +132,11 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   nsig <- min(100, round(length(fc) / 5))
   sel.idx <- 1:length(cn) ## all
   sel.idx <- grep("DELETED", cn, invert = TRUE)
+  dbg(">>> [pgx-sign] point 3")
   idx <- list(1:nsig, sel.idx)
   sig100.up <- rhdf5::h5read(h5.file, "signature/sig100.up", index = idx)
   sig100.dn <- rhdf5::h5read(h5.file, "signature/sig100.dn", index = idx)
+  dbg(">>> [pgx-sign] point 4")
   colnames(sig100.up) <- cn[sel.idx]
   colnames(sig100.dn) <- cn[sel.idx]
 
@@ -145,10 +148,12 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     gmt <- rbind(sig100.up, sig100.dn)
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)
     names(gmt) <- colnames(sig100.up)
+    dbg(">>> [pgx-sign] point 5")
     suppressMessages(suppressWarnings(
       res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
       # https://github.com/ctlab/fgsea/issues/103
     )) ## really unsigned???
+    dbg(">>> [pgx-sign] point 6")
   })
 
   res$ES <- NULL
@@ -165,6 +170,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   }
   gmt <- gmt[sel]
   length(gmt)
+  dbg(">>> [pgx-sign] point 7")
 
   ## --------------------------------------------------
   ## Fisher test
@@ -175,12 +181,14 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   top.dn <- head(names(sort(+fc.dn)), 3 * nsig)
   top.fc <- unique(c(top.up, top.dn))
   bg <- intersect(names(fc), rn)
+  dbg(">>> [pgx-sign] point 8")
   system.time({
     stats <- playbase::gset.fisher(top.fc, gmt,
       background = bg, fdr = 1,
       min.genes = 0, nmin = 0
     )
   })
+  dbg(">>> [pgx-sign] point 9")
   or.max <- max(stats$odd.ratio[!is.infinite(stats$odd.ratio)])
   stats$odd.ratio[is.infinite(stats$odd.ratio)] <- max(99, 2 * or.max)
 
@@ -193,10 +201,12 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     gg1 <- unique(names(c(Matrix::head(fc1, nsig), Matrix::tail(fc1, nsig))))
     row.idx <- match(gg1, rn)
     col.idx <- match(sel, cn)
+    dbg(">>> [pgx-sign] point 10")
     G <- rhdf5::h5read(h5.file, "data/matrix", index = list(row.idx, col.idx))
     G[which(G < -999999)] <- NA
     dimnames(G) <- list(gg1, sel)
     dim(G)
+    dbg(">>> [pgx-sign] point 11")
 
     ## rank correlation??
     rG <- apply(G[gg1, ], 2, rank, na.last = "keep")
@@ -206,6 +216,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     suppressWarnings({
       rho <- stats::cor(rG, rfc, use = "pairwise")[, 1]
     })
+    dbg(">>> [pgx-sign] point 12")
   })
   remove(G, rG, rfc)
 
@@ -213,19 +224,23 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## Cosine distance with sparse GSET matrix
   ## --------------------------------------------------
   system.time({
+    dbg(">>> [pgx-sign] point 13")
     bg <- intersect(names(fc), rn)
     gmt100.up <- unlist(apply(sig100.up[, sel], 2, list), recursive = FALSE)
     gmt100.dn <- unlist(apply(sig100.dn[, sel], 2, list), recursive = FALSE)
+    dbg(">>> [pgx-sign] point 14")
     G1 <- playbase::gmt2mat(gmt100.up, bg = bg)
     G2 <- playbase::gmt2mat(gmt100.dn, bg = bg)
     G1 <- G1[match(bg, rownames(G1)), ]
     G2 <- G2[match(bg, rownames(G2)), colnames(G1)]
+    dbg(">>> [pgx-sign] point 15")
     G <- G1 - G2
     dim(G)
     remove(G1, G2)
     ##  tau <- qlcMatrix::corSparse( G[bg,], cbind(fc[bg]) )[,1]
     tau <- qlcMatrix::cosSparse(G[bg, ], cbind(fc[bg]))[, 1]
     jj <- match(res$pathway, colnames(G))
+    dbg(">>> [pgx-sign] point 16")
     res$tau <- tau[jj]
   })
 
@@ -235,12 +250,13 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   jj <- match(res$pathway, names(rho))
   res$rho <- rho[jj]
   res$R2 <- rho[jj]**2
-
+  dbg(">>> [pgx-sign] point 17")
   ii <- match(res$pathway, rownames(stats))
   res$odd.ratio <- stats$odd.ratio[ii]
   res$overlap <- stats$overlap[ii]
   res$score <- abs(res$rho) * res$NES * log(pmax(res$odd.ratio, 1)) * abs(res$tau)
   res <- res[order(abs(res$score), decreasing = TRUE), ]
+  dbg(">>> [pgx-sign] point 18")
 
   ## force garbage collection...
   remove(gmt, stats)

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -113,7 +113,7 @@ pgx.computeConnectivityScores <- function(pgx, sigdb, ntop = 200, contrasts = NU
 #'
 #' @export
 pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm = 10000) {
-  bpparam <- BiocParallel::MulticoreParam(1)
+  bpparam <- BiocParallel::MulticoreParam(2)
 
   if (is.null(names(fc))) stop("fc must have names")
   ## mouse... mouse...

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -116,7 +116,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   if (is.null(names(fc))) stop("fc must have names")
   ## mouse... mouse...
   names(fc) <- toupper(names(fc))
-  dbg(">>> [pgx-sign] h5.file")
+  dbg(paste0(">>> [pgx-sign-file] ", h5.file))
   dbg(">>> [pgx-sign] point 1")
 
   ## or instead compute correlation on top100 fc genes (read from file)
@@ -154,7 +154,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     names(gmt) <- colnames(sig100.up)
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
-      gmt_blocks <- split_list(gmt, 1000)
+      gmt_blocks <- split_list(gmt, 5000)
       results_list <- list()
       for (i in seq_along(gmt_blocks)) {
         block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), nPermSimple = nperm, scoreType = "pos")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -147,27 +147,27 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## Test signatures using fGSEA (this is pretty fast. amazing.)
   ## ------------------------------------------------------------
   ## combine up/down into one (unsigned GSEA test)
-  split_list <- function(input_list, chunk_size) {
-    split(input_list, ceiling(seq_along(input_list)/chunk_size))
-  }
+  # split_list <- function(input_list, chunk_size) {
+  #   split(input_list, ceiling(seq_along(input_list)/chunk_size))
+  # }
   system.time({
     gmt <- rbind(sig100.up, sig100.dn)
     gmt <- unlist(apply(gmt, 2, list), recursive = FALSE)
     names(gmt) <- colnames(sig100.up)
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
-      gmt_blocks <- split_list(gmt, 2000)
-      results_list <- list()
-      for (i in seq_along(gmt_blocks)) {
-        block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos", BPPARAM = bpparam)
-        block_result$ES <- NULL
-        block_result$leadingEdge <- NULL
-        block_result$pval <- NULL
-        results_list[[i]] <- block_result
-      }
-      res <- do.call(rbind, results_list)
+      # gmt_blocks <- split_list(gmt, 2000)
+      # results_list <- list()
+      # for (i in seq_along(gmt_blocks)) {
+      #   block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos", BPPARAM = bpparam)
+      #   block_result$ES <- NULL
+      #   block_result$leadingEdge <- NULL
+      #   block_result$pval <- NULL
+      #   results_list[[i]] <- block_result
+      # }
+      # res <- do.call(rbind, results_list)
 
-      # res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos")
+      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos", BPPARAM = bpparam)
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -114,7 +114,6 @@ pgx.computeConnectivityScores <- function(pgx, sigdb, ntop = 200, contrasts = NU
 #' @export
 pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm = 10000) {
   if (is.null(names(fc))) stop("fc must have names")
-  browser()
   ## mouse... mouse...
   names(fc) <- toupper(names(fc))
 

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -154,7 +154,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     names(gmt) <- colnames(sig100.up)
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
-      gmt_blocks <- split_list(gmt, 5000)
+      gmt_blocks <- split_list(gmt, 2000)
       results_list <- list()
       for (i in seq_along(gmt_blocks)) {
         block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -155,6 +155,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
     dbg(">>> [pgx-sign] point 5")
     #suppressMessages(suppressWarnings(
       gmt_blocks <- split_list(gmt, 1000)
+      results_list <- list()
       for (i in seq_along(gmt_blocks)) {
         block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), nPermSimple = nperm, scoreType = "pos")
         block_result$ES <- NULL

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -167,7 +167,8 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
       # }
       # res <- do.call(rbind, results_list)
 
-      res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos", BPPARAM = bpparam)
+      # res <- fgsea::fgseaMultilevel(gmt, abs(fc), nPermSimple = nperm, scoreType = "pos", BPPARAM = bpparam)
+      res <- fgsea::fgseaSimple(gmt, abs(fc), nperm = nperm, scoreType = "pos", BPPARAM = bpparam)
       # https://github.com/ctlab/fgsea/issues/103
     #)) ## really unsigned???
     dbg(">>> [pgx-sign] point 6")

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -113,6 +113,8 @@ pgx.computeConnectivityScores <- function(pgx, sigdb, ntop = 200, contrasts = NU
 #'
 #' @export
 pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm = 10000) {
+  bpparam <- BiocParallel::MulticoreParam(1)
+
   if (is.null(names(fc))) stop("fc must have names")
   ## mouse... mouse...
   names(fc) <- toupper(names(fc))
@@ -157,7 +159,7 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
       gmt_blocks <- split_list(gmt, 2000)
       results_list <- list()
       for (i in seq_along(gmt_blocks)) {
-        block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos")
+        block_result <- fgsea::fgseaMultilevel(gmt_blocks[[i]], abs(fc), scoreType = "pos", BPPARAM = bpparam)
         block_result$ES <- NULL
         block_result$leadingEdge <- NULL
         block_result$pval <- NULL


### PR DESCRIPTION
This PR is aimed at reducing the RAM footprint of PGX computation. Basically it boils down to two changes:

1. Use of `matrixStats` for rank computation. Using `apply` was both slower and memory hungry. Nevertheless, this updated operation still causes a peak of RAM usage. Can be further reduced by ranking the matrix by chunks.
2. Assert further control on the multi-threading functionalities of `fgsea` and `GSVA`. Both this functions can take up large chunks of memory when used on a multi-threaded configuration (crashing the compute workers), for that reason, I have set them to 1 thread on most scenarios except `pgx.correlateSignatureH5`, where 1 thread tragically affects performance, keeping it at 2 threads provides decent enough performance and much more safe RAM usage.

These upgrades do not affect the results. Please @mauromiguelm double check on your end.