### PR TITLE
Fix #972: Cell type profiling not working with mouse dataset

### DIFF
--- a/R/compute2-extra.R
+++ b/R/compute2-extra.R
@@ -327,7 +327,6 @@ compute_deconvolution <- function(pgx, rna.counts = pgx$counts, full = FALSE) {
   }
 
   counts <- rna.counts
-  rownames(counts) <- toupper(pgx$genes[rownames(counts), "gene_name"])
   res <- pgx.multipleDeconvolution(counts, refmat = refmat, methods = methods)
 
   pgx$deconv <- res$results


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/972

No need to rename rows of `counts`, doing so for species different than human breaks the cell deconvolution methods.

Tests can be done with dataset 7337bf045 (Mouse) and example data for human.