### PR TITLE
Fix gene set intersection and add custom geneset

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -814,7 +814,7 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
   ## Load the annotation resource.
   if (is.null(ah)) ah <- AnnotationHub::AnnotationHub()
   cat("querying AnnotationHub for", organism, "\n")
-  browser()
+
   ahDb <- AnnotationHub::query(ah, pattern = c(organism, "OrgDb"))
 
   ## select on exact organism name
@@ -848,15 +848,17 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
         keys = go_id, keytype = "GOALL",
         column = "SYMBOL", multiVals = "list"
       )
-      sets <- lapply(sets, function(s) intersect(s, genes))
+
+      # intersect with genes should be done later, as we need to count the gset size before
+      # sets <- lapply(sets, function(s) intersect(s, genes))
 
       ## get GO title
-      go <- mget(names(sets), GO.db::GOTERM, ifnotfound = NA)
-      go_term <- sapply(go, function(x) x@Term)
-      new_names <- paste0("GO_", k, ":", go_term, " (", sub("GO:", "GO_", names(sets)), ")")
+      go <- sapply(GOTERM[names(sets)], Term)
+      new_names <- paste0("GO_", k, ":", go, " (", sub("GO:", "GO_", names(sets)), ")")
       names(sets) <- new_names
 
       ## add to list
+      browser()
       go.gmt <- c(go.gmt, sets)
     }
   }

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -814,6 +814,7 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
   ## Load the annotation resource.
   if (is.null(ah)) ah <- AnnotationHub::AnnotationHub()
   cat("querying AnnotationHub for", organism, "\n")
+  browser()
   ahDb <- AnnotationHub::query(ah, pattern = c(organism, "OrgDb"))
 
   ## select on exact organism name
@@ -847,7 +848,7 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
         keys = go_id, keytype = "GOALL",
         column = "SYMBOL", multiVals = "list"
       )
-      sets <- parallel::mclapply(sets, function(s) intersect(s, genes))
+      sets <- lapply(sets, function(s) intersect(s, genes))
 
       ## get GO title
       go <- mget(names(sets), GO.db::GOTERM, ifnotfound = NA)

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -839,7 +839,6 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
     ont_classes <- c("BP", "CC", "MF")
     k <- "BP"
     for (k in ont_classes) {
-      browser()
       go_id <- AnnotationDbi::mapIds(orgdb,
         keys = k, keytype = "ONTOLOGY",
         column = "GO", multiVals = "list"
@@ -863,7 +862,6 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
       go.gmt <- c(go.gmt, sets)
     }
   }
-  browser()
   go.gmt
 }
 
@@ -955,6 +953,7 @@ pgx.add_GMT <- function(pgx, custom.geneset = NULL, max.genesets = 20000) {
     message("[pgx.add_GMT] Adding custom genesets...")
     ## convert gmt standard to SPARSE matrix: gset in rows, genes in
     ## columns.
+
     custom_gmt <- playbase::createSparseGenesetMatrix(
       gmt.all = custom.geneset$gmt,
       min.geneset.size = 3,
@@ -1051,6 +1050,7 @@ pgx.add_GMT <- function(pgx, custom.geneset = NULL, max.genesets = 20000) {
   G <- playbase::normalize_cols(G)
 
   pgx$GMT <- G
+  pgx$custom.geneset <- custom.geneset
   message(glue::glue("[pgx.add_GMT] Final GMT: {nrow(G)}x{ncol(G)}"))
   rm(gsetX.bygroup, gsetX, G)
   gc()

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -839,6 +839,7 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
     ont_classes <- c("BP", "CC", "MF")
     k <- "BP"
     for (k in ont_classes) {
+      browser()
       go_id <- AnnotationDbi::mapIds(orgdb,
         keys = k, keytype = "ONTOLOGY",
         column = "GO", multiVals = "list"
@@ -853,15 +854,16 @@ getOrganismGO <- function(organism, genes, ah = NULL) {
       # sets <- lapply(sets, function(s) intersect(s, genes))
 
       ## get GO title
-      go <- sapply(GOTERM[names(sets)], Term)
+      go <- sapply(GO.db::GOTERM[names(sets)], Term)
       new_names <- paste0("GO_", k, ":", go, " (", sub("GO:", "GO_", names(sets)), ")")
       names(sets) <- new_names
 
       ## add to list
-      browser()
+
       go.gmt <- c(go.gmt, sets)
     }
   }
+  browser()
   go.gmt
 }
 


### PR DESCRIPTION
This PR introduces several fixes in `getOrganismGO`:

- Remove `getOrganismGO` function incorrectly intersecting the gene sets with the input genes.

- Passes go terms custom genesets to the test geneset module via custom.genesets argument in pgx compute. This will allow correct calculation of raw geneset size.

- Fixes implementation of `getOrganismGO`, which was crashing.

**Fixes https://github.com/bigomics/omicsplayground/issues/978**