### PR TITLE
Fix subscript out of bounds and incorrect length errors

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -409,7 +409,8 @@ pgx.createPGX <- function(counts,
       pgx$genes <- pgx$genes[is.proteincoding, , drop = FALSE]
     }
 
-    keep <- rownames(pgx$genes)
+    keep <- match(rownames(pgx$genes), rownames(pgx$counts))
+
     pgx$counts <- pgx$counts[keep, , drop = FALSE]
     if (!is.null(pgx$X)) {
       keep <- intersect(keep, rownames(pgx$X))

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -413,7 +413,7 @@ pgx.createPGX <- function(counts,
 
     pgx$counts <- pgx$counts[keep, , drop = FALSE]
     if (!is.null(pgx$X)) {
-      keep <- intersect(keep, rownames(pgx$X))
+      keep <- match(rownames(pgx$genes), rownames(pgx$X))
       pgx$X <- pgx$X[keep, , drop = FALSE] ##  NOT ALIGNED???
     }
   }


### PR DESCRIPTION
fixes https://github.com/bigomics/omicsplayground/issues/977
fixes https://github.com/bigomics/omicsplayground/issues/980

This pull request fixes two issues in the code. The issue is a subscript out of bounds error in the `pgx$counts` function, which was solved by using index instead of rownames for matrix subsetting.