### PR TITLE
Fix issue with `playbase::read_counts` not being able to read standard matrix

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -39,7 +39,7 @@ read.as_matrix <- function(file, skip_row_check = FALSE, row.names = 1) {
     check.names = FALSE,
     header = TRUE,
     dec = dec,
-    fill = TRUE,
+    # fill = TRUE, ## fill=TRUE will fail for some datasets
     skip = skip.rows,
     blank.lines.skip = TRUE,
     stringsAsFactors = FALSE,


### PR DESCRIPTION
The problem was caused by the `fill=TRUE` parameter, which failed for certain datasets due to unknown reason. This PR removes the `fill=TRUE` parameter to resolve the issue.

Optinally, we can fill the NAs, but since many clients do not want that, I left the autofill disable and the decision to fill or not NAs should be done at the upload module. [NEEDS REVIEW]