### PR TITLE
Use omics color palette

### DIFF
--- a/R/gset-gsea.r
+++ b/R/gset-gsea.r
@@ -1112,12 +1112,13 @@ gsea.enplot <- function(rnk, gset, names = NULL, main = NULL,
   kk <- c(seq(1, length(rnk) * 0.99, floor(length(rnk) / 20)), length(rnk))
   length(kk)
   i <- 1
+  pal <- grDevices::colorRampPalette(c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red")))(32)
   for (i in 1:(length(kk) - 1)) {
     r <- mean(rnk[kk[c(i, i + 1)]], na.rm = TRUE)
     r1 <- (r / max(abs(rnk), na.rm = TRUE))
     r1 <- abs(r1)**0.5 * sign(r1)
     irnk <- floor(31 * (1 + r1) / 2)
-    cc <- gplots::bluered(32)[1 + irnk]
+    cc <- pal[1 + irnk]
     graphics::rect(kk[i], y0 - 1.05 * dy, kk[i + 1], y0 - 0.65 * dy, col = cc, border = NA)
   }
 

--- a/R/gx-heatmap.r
+++ b/R/gx-heatmap.r
@@ -548,7 +548,7 @@ gx.splitmap <- function(gx, split = 5, splitx = NULL,
     colmax <- max(abs(gx[, ]), na.rm = TRUE)
     col_scale <- circlize::colorRamp2(
       c(-colmax, 0, colmax),
-      c("royalblue3", "grey90", "indianred3")
+      c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red"))
     )
   } else {
     colmin <- min(gx[, ], na.rm = TRUE)

--- a/R/gx-heatmap.r
+++ b/R/gx-heatmap.r
@@ -542,7 +542,7 @@ gx.splitmap <- function(gx, split = 5, splitx = NULL,
       zz <- c(zlim[1], zmean, zlim[2])
       if (zlim[1] < 0) zz <- c(zlim[1], 0, zlim[2])
     }
-    col_scale <- circlize::colorRamp2(zz, c("royalblue3", "grey90", "indianred3"))
+    col_scale <- circlize::colorRamp2(zz, c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red")))
   } else if (symm.scale) {
     colmax <- 1
     colmax <- max(abs(gx[, ]), na.rm = TRUE)
@@ -556,7 +556,7 @@ gx.splitmap <- function(gx, split = 5, splitx = NULL,
     colmean <- mean(gx[, ], na.rm = TRUE)
     col_scale <- circlize::colorRamp2(
       c(colmin, colmean, colmax),
-      c("royalblue3", "grey90", "indianred3")
+      c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red"))
     )
   }
 

--- a/R/pgx-correlation.R
+++ b/R/pgx-correlation.R
@@ -118,6 +118,7 @@ pgx.plotPartialCorrelationGraph <- function(res, gene, rho.min = 0.1, nsize = -1
   igraph::E(G)$width <- edge.width * ew**1.5
   igraph::E(G)$color <- c("red", "darkgreen")[1 + 1 * (sign(R[ee]) > 0)]
   igraph::E(G)$color <- c("#FF000033", "#44444433")[1 + 1 * (sign(R[ee]) > 0)]
+  igraph::E(G)$color <- c(paste0(omics_colors("red"), "33"), paste0(omics_colors("brand_blue"), "33"))[1 + 1 * (sign(R[ee]) > 0)]
 
   ## delete weak edges
   G1 <- igraph::delete_edges(G, which(abs(igraph::E(G)$weight) < rho.min))
@@ -501,7 +502,7 @@ pgx.testPhenoCorrelation <- function(df, plot = TRUE, cex = 1, compute.pv = TRUE
     Q <- (Q + t(Q)) / 2
   }
 
-  BLUERED <- grDevices::colorRampPalette(c("blue3", "white", "red3"))
+  BLUERED <- grDevices::colorRampPalette(c(omics_colors("brand_blue"), "white", omics_colors("red")))
 
   if (plot == TRUE) {
     if (compute.pv) {

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -5638,7 +5638,7 @@ pgx.splitHeatmapFromMatrix <- function(X, annot = NULL, idx = NULL, splitx = NUL
     colorbar_grid = grid_params,
     x = xtips[colnames(x1)],
     y = ytips[rownames(x1)],
-    colors = c("royalblue3", "grey90", "indianred3"),
+    colors = c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red")),
     zmid = 0,
     zmin = -zmax,
     zmax = zmax,

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -3242,12 +3242,10 @@ pgx.scatterPlotXY.BASE <- function(pos, var = NULL, type = NULL, col = NULL, tit
 
     ## -------------- set colors
 
-    cpal <- colorspace::diverge_hcl(64, c = 60, l = c(30, 100), power = 1)
-    cpal <- grDevices::colorRampPalette(c("#313695", "#FFFFDF", "#A50026"))(64)
     if (!is.null(col)) {
       cpal <- grDevices::colorRampPalette(col)(64)
     } else {
-      cpal <- grDevices::colorRampPalette(c("#3136B5", "#FFFFDF", "#B50026"))(64)
+      cpal <- grDevices::colorRampPalette(c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red")))(64)
     }
     cpal <- sapply(1:length(cpal), function(i) add_opacity(cpal[i], 0.2 + 0.8 * abs(i - 32.5) / 32))
 
@@ -3625,7 +3623,7 @@ pgx.scatterPlotXY.GGPLOT <- function(pos, var = NULL, type = NULL, col = NULL, c
   if (type == "numeric") {
     z <- as.numeric(var)
     cpal <- rev(viridis::viridis(11))
-    cpal <- rev(RColorBrewer::brewer.pal(11, "RdYlBu")) ## default
+    cpal <- c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red"))# rev(RColorBrewer::brewer.pal(11, "RdYlBu")) ## default
     if (!is.null(col)) {
       cpal <- col
     }
@@ -3976,7 +3974,7 @@ pgx.scatterPlotXY.PLOTLY <- function(pos,
     z <- as.numeric(var)
     z1 <- NULL
     if (is.null(col)) {
-      cpal <- rev(RColorBrewer::brewer.pal(11, "RdYlBu"))
+      cpal <- c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red"))# rev(RColorBrewer::brewer.pal(11, "RdYlBu"))
     } else {
       cpal <- col
     }

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2310,7 +2310,7 @@ gsea.enplotly <- function(fc, gset, cex = 1, main = NULL, xlab = NULL, ticklen =
   r1 <- (fx / max(abs(fx), na.rm = TRUE))
   r1 <- abs(r1)**0.66 * sign(r1)
   suppressWarnings(
-    cc <- gplots::colorpanel(21, "royalblue3", "grey90", "indianred3")
+    cc <- gplots::colorpanel(21, omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red"))
   )
   irnk <- 1 + round((length(cc) - 1) * (1 + r1) * 0.5)
 

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -1244,7 +1244,7 @@ ggVolcano <- function(x,
                       title = "Volcano plot",
                       colors = c(
                         up = "#f23451",
-                        notsig = "#707070AA",
+                        notsig = "#8F8F8F",
                         notsel = "#cccccc88",
                         down = "#3181de"
                       ),

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -4468,7 +4468,7 @@ plotlyMA <- function(x, y, names, label.names = names,
                      lfc = 1, psig = 0.05, showlegend = TRUE, highlight = NULL,
                      marker.size = 5, label = NULL, label.cex = 1,
                      color_up_down = TRUE,
-                     colors = c(up = "#f23451", notsig = "#8F8F8F", down = "#1f77b4"),
+                     colors = c(up = "#f23451", notsig = "#8F8F8F", down = "#3181de"),
                      marker.type = "scatter", source = "plot1",
                      displayModeBar = TRUE) {
   if (is.null(highlight)) highlight <- names
@@ -4694,7 +4694,7 @@ plotlyVolcano <- function(x,
                           color_up_down = TRUE,
                           colors = c(
                             up = "#f23451", notsig = "#8F8F8F",
-                            down = "#1f77b4", notsel = "#cccccc88"
+                            down = "#3181de", notsel = "#cccccc88"
                           ),
                           marker.type = "scatter",
                           displayModeBar = TRUE,

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -65,6 +65,7 @@ heatmapWithAnnot <- function(F, anno.type = c("boxplot", "barplot"),
   ht <- ComplexHeatmap::Heatmap(
     t(F),
     name = "logFC",
+    col = circlize::colorRamp2(colors = c(omics_colors("brand_blue"), omics_colors("grey"), omics_colors("red")), breaks = c(-10, 0, 10)),
     top_annotation = ha,
     row_names_gp = grid::gpar(fontsize = row_fontsize),
     column_names_gp = grid::gpar(fontsize = column_fontsize),


### PR DESCRIPTION
This PR is linked to https://github.com/bigomics/omicsplayground/pull/1095

## Description

Moved some plot features to use our own omics palette. The most obvious change being the use of our "brand blue" instead of the previous "royalblue3".

Overall this provides a more consistent feel across the boards.