### PR TITLE
fix: use union, not c

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -1075,10 +1075,9 @@ pgx.add_GMT <- function(pgx, custom.geneset = NULL, max.genesets = 20000) {
     # make sure we dont miss CUSTOM genesets due to size.ok exclusion
     if (length(idx_custom_gmt) > 0) {
       names(idx_custom_gmt) <- colnames(G)[idx_custom_gmt]
-      size.ok <- c(size.ok, idx_custom_gmt)
+      size.ok <- union(size.ok, idx_custom_gmt)
     }
   }
-
   G <- G[, size.ok, drop = FALSE]
 
   # normalize columns (required for some methods downstream)


### PR DESCRIPTION
## Problem
By doing `c(size.ok, idx_custom_gmt)`, we are merging the id's of genesets whose size is OK with the custom ones. Therefore, if a custom gmt has OK size, it will be duplicated.

## Solution
Instead of merging vectors, we can use `union` which will put together all the distinct ids with no duplicates.