### PR TITLE
Collapse error: human ortholog is empty but not detected

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -366,8 +366,9 @@ pgx.createPGX <- function(counts,
   if (do.filter) {
     if (only.known) {
       message("[createPGX] removing genes without symbol...")
-      no.symbol <- (is.na(pgx$genes$symbol) | pgx$genes$symbol == "")
+      no.symbol <- (is.na(pgx$genes$symbol) | pgx$genes$symbol %in% c("", "-"))
       pgx$genes <- pgx$genes[which(!no.symbol), ]
+      browser()
     }
 
     if (only.proteincoding) {

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -368,7 +368,6 @@ pgx.createPGX <- function(counts,
       message("[createPGX] removing genes without symbol...")
       no.symbol <- (is.na(pgx$genes$symbol) | pgx$genes$symbol %in% c("", "-"))
       pgx$genes <- pgx$genes[which(!no.symbol), ]
-      browser()
     }
 
     if (only.proteincoding) {

--- a/R/pgx-functions.R
+++ b/R/pgx-functions.R
@@ -1500,8 +1500,10 @@ collapse_by_humansymbol <- function(obj, annot) {
   annot <- cbind(annot, rownames = rownames(annot))
   target <- c("human_ortholog", "symbol", "gene_name", "rownames")
   target <- intersect(target, colnames(annot))
-  target <- target[which(colSums(is.na(annot[, target])) < 1)]
-  target
+  complete_targets <- lapply(target, function(x){
+    sum(is.na(annot[, x]) | annot[, x] %in% c("")) < 1
+  }) |> unlist()
+  target <- target[complete_targets]
   if (length(target) == 0) {
     message("[map_humansymbol] WARNING: could not find symbol mapping column.")
     return(obj)


### PR DESCRIPTION
Found a case where human ortholog was empty as "" (or "-") instead of NAs. This ensures we check it.