### PR TITLE
fix: control no matches

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -1223,13 +1223,20 @@ getOrgGeneInfo <- function(organism, gene, feature, ortholog, datatype, as.link 
 
   ## get info from different environments
   info <- lapply(cols, function(k) {
-    AnnotationDbi::select(
-      orgdb,
-      keys = gene,
-      keytype = keytype,
-      columns = k
-    )[[k]]
+    tryCatch({
+      AnnotationDbi::select(
+        orgdb,
+        keys = gene,
+        keytype = keytype,
+        columns = k
+      )[[k]]
+    }, error = function(w) {
+      NULL
+    })
   })
+  if(is.null(unlist(info))){
+    return(NULL)
+  }
   names(info) <- cols
 
   info[["ORGANISM"]] <- organism


### PR DESCRIPTION
for some species (e.g. arabidopsis thaliana), some genes are not found, which makes the gene info to display a big error message, with thi we make sure that if not found, the info is NULL

Note this error is different that the one we solved for yeast, as using the SYMBOL column is fine, just that the query we make to it is not existent.

![image](https://github.com/user-attachments/assets/e9f246b6-12d3-476b-a986-ade19fc57384)

--

@ivokwee This can be tested with arabidopsis datasets, I can send it if you don't have it