### PR TITLE
improve read_counts and read.as_matrix speed. 

### DIFF
--- a/R/pgx-check.R
+++ b/R/pgx-check.R
@@ -17,12 +17,21 @@ pgx.checkINPUT <- function(
   check_return <- list()
 
   if (datatype == "COUNTS" || datatype == "EXPRESSION") {
-    # remove special characters before converting to numeric (keep commas, dots) as they define the decimal separator
-    df_clean <- apply(df_clean, 2, function(x) gsub("[^0-9,.]", "", x))
-    # convert matrix from character to numeric, sometimes we receive character matrix from read.csv function
-    df_clean <- apply(df_clean, 2, as.numeric, simplify = TRUE)
-    rownames(df_clean) <- rownames(df)
 
+    df.class <- apply(df_clean, 2, class)
+    if(any(df.class == "character")) {
+
+      # remove special characters before converting to numeric (keep
+      # commas, dots) as they define the decimal separator
+      jj <- which(df.class == "character")
+      df_clean[,jj] <- apply(df_clean[,jj], 2, function(x) gsub("[^0-9,.]", "", x))
+      
+      # convert matrix from character to numeric, sometimes we receive
+      # character matrix from read.csv function
+      df_clean[,jj] <- apply(df_clean[,jj], 2, as.numeric, simplify = TRUE)
+    }
+    
+    rownames(df_clean) <- rownames(df)
     sample_names <- colnames(df_clean)
 
     # check if any value in df had a non-NA value that was converted to NA in df_clean
@@ -34,14 +43,14 @@ pgx.checkINPUT <- function(
 
     # replace infinite values in counts by the maximum value of the feature + 10%
     # check if there are any infinite values
-    ANY_INFINITE <- which(is.infinite(df_clean), arr.ind = TRUE)
+    ##ANY_INFINITE <- which(is.infinite(df_clean), arr.ind = TRUE)
+    ANY_INFINITE <- which(df_clean == Inf | df_clean == -Inf, arr.ind = TRUE)    
 
     if (length(ANY_INFINITE) > 0 && PASS) {
-      df_clean <- apply(df_clean, 1, function(x) {
-        max_val <- max(x, na.rm = TRUE)
-        ifelse(is.infinite(x), max_val * 1.1, x)
-      })
-      check_return$e28 <- paste("gene:", rownames(ANY_INFINITE), " and ", "sample:", colnames(df_clean)[ANY_INFINITE[, 2]])
+      ## replace Inf with NA
+      df_clean[ ANY_INFINITE ] <- NA
+      check_return$e28 <- paste("gene:", rownames(ANY_INFINITE), " and ",
+                                "sample:", colnames(df_clean)[ANY_INFINITE[, 2]])
     }
 
     # check for duplicated colnanes (gives error)
@@ -62,7 +71,7 @@ pgx.checkINPUT <- function(
     }
 
     # check for zero count rows, remove them
-    ANY_ROW_ZERO <- which(rowSums(df_clean, na.rm = TRUE) == 0, )
+    ANY_ROW_ZERO <- which(Matrix::rowSums(df_clean, na.rm = TRUE) == 0, )
 
     if (length(ANY_ROW_ZERO) > 0 && PASS) {
       # get the row names with all zeros
@@ -81,7 +90,7 @@ pgx.checkINPUT <- function(
     }
 
     # check for zero count columns, remove them
-    ANY_COLUMN_ZERO <- which(colSums(df_clean) == 0)
+    ANY_COLUMN_ZERO <- which(Matrix::colSums(df_clean) == 0)
 
     if (length(ANY_COLUMN_ZERO) > 0 && PASS) {
       check_return$e10 <- names(ANY_COLUMN_ZERO)

--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -19,7 +19,9 @@
 #' mymatrix <- read.as_matrix(mydata.csv)
 #' }
 #' @export
-read.as_matrix <- function(file, skip_row_check = FALSE, row.names = 1) {
+read.as_matrix <- function(file, skip_row_check = FALSE, as.char=TRUE,
+                           as.matrix=TRUE, row.names = 1) {
+
   ## determine if there are empty lines in header
   x0 <- data.table::fread(
     file = file,
@@ -48,6 +50,11 @@ read.as_matrix <- function(file, skip_row_check = FALSE, row.names = 1) {
     integer64 = "numeric"
   )
 
+  ## see: https://github.com/Rdatatable/data.table/issues/2607
+  coln.int64 <- names(which(sapply(x0, bit64::is.integer64)))
+  if (length(coln.int64) > 0L)
+    x0[, c(coln.int64) := lapply(.SD, as.numeric), .SDcols = coln.int64]
+  
   ## For csv with missing rownames field at (1,1) in the header,
   ## fill=TRUE will fail. Check header with slow read.csv() and
   ## correct if needed. fread is fast but is not so robust...
@@ -61,51 +68,63 @@ read.as_matrix <- function(file, skip_row_check = FALSE, row.names = 1) {
     colnames(x0) <- colnames(hdr)
   }
 
-  x <- NULL
+  ## give first column name
+  if(colnames(x0)[1] == '') colnames(x0)[1] <- "row.names"
+  
   ## drop rows without rownames
   sel <- which(!as.character(x0[[1]]) %in% c("", " ", "NA", "na", "-", NA))
-  if (length(sel)) {
-    ##
-    x <- x0[sel, , drop = FALSE]
-    # convert x from data.table to matrix. as.matrix means we do not
-    # have mixed types (such as in dataframes). This is needed as
-    # fread reads numeric as integer64, which is not supported by
-    # matrix at this stage since we handle samples, counts and
-    # contrasts, it is dangerous to force conversion to numeric hence,
-    # the conversion from character to numeric for counts is handled
-    # at pgx.checkINPUT
-    colnames_x <- colnames(x)
-    x <- sapply(1:ncol(x), function(i) {
-      as.character(x[[i]]) ## always character!
-    })
-    colnames(x) <- colnames_x
-  } else {
+  if (length(sel)==0) {
     return(NULL)
   }
+  x <- x0[sel, , drop = FALSE]
 
+  # convert x from data.table to matrix. as.matrix means we do not
+  # have mixed types (such as in dataframes). This is needed as
+  # fread reads numeric as integer64, which is not supported by
+  # matrix at this stage since we handle samples, counts and
+  # contrasts, it is dangerous to force conversion to numeric hence,
+  # the conversion from character to numeric for counts is handled
+  # at pgx.checkINPUT
+  if(as.char) {
+    colnames_x <- colnames(x)[-1]
+    x[, c(colnames_x) := lapply(.SD, as.character), .SDcols = colnames_x]
+  }
+  
   ## for character matrix, we strip whitespace
-  if (is.character(x)) {
-    x <- trimws(x)
+  which.char <- which( sapply(x,class) == "character")
+  if (length(which.char)) {
+    char.cols <- colnames(x)[which.char]
+    x[, c(char.cols) := lapply(.SD, trimws), .SDcols = char.cols]    
   }
 
-  ## set rownames
-  if (!is.null(row.names) && !is.na(row.names) && row.names >= 1) {
-    rownamesx <- x[, row.names]
-    x <- x[, -row.names, drop = FALSE]
-    rownames(x) <- rownamesx
+  ## set rownames, convert to matrix
+  if(as.matrix) {
+    x <- as.matrix(x, rownames = row.names)   ## this is slow!!
+  } else {
+    rownames(x) <- x[[1]]
+    if(!is.null(row.names)) {
+      data.table::set(x, j=as.integer(row.names), value=NULL)
+    }
   }
 
   ## some csv have trailing empty rows/cols at end of table
-  if (NCOL(x) && !skip_row_check) { # bypass in case full NA rows
-    empty.row <- (rowSums(is.na(x)) == ncol(x))
+  last.row.empty <- mean(is.na(x[nrow(x),])) == 1
+  last.col.empty <- mean(is.na(x[,ncol(x)])) == 1
+
+  if (last.row.empty && !skip_row_check) { # bypass in case full NA rows
+    empty.row <- (rowSums(is.na(x) | x %in% c("", NA, "NA", " ")) == ncol(x))    
+    empty.row <- empty.row & rownames(x) %in% c(NA,""," ")
     if (tail(empty.row, 1)) {
       n <- which(!rev(empty.row))[1] - 1
       ii <- (nrow(x) - n + 1):nrow(x)
       x <- x[-ii, , drop = FALSE]
     }
+  }
+  if (last.col.empty && !skip_row_check) { # bypass in case full NA rows
     ## some csv have trailing empty columns at end of table
     ## detect as empty column, columns with NA and weird characters
     empty.col <- (colSums(is.na(x) | x %in% c("", "-", ".", "NA", " ")) == nrow(x))
+    empty.col <-  empty.col & colnames(x) %in% c(NA,""," ")
     if (tail(empty.col, 1)) {
       n <- which(!rev(empty.col))[1] - 1
       ii <- (ncol(x) - n + 1):ncol(x)
@@ -251,21 +270,22 @@ read_files <- function(dir = ".", pattern = NULL) {
 #' @export
 read_counts <- function(file, first = FALSE, unique = FALSE, paste_char = "_") {
   if (is.character(file)) {
-    df <- read.as_matrix(file)
+    df <- read.as_matrix(file, as.char=FALSE)
   } else if (is.matrix(file) || is.data.frame(file)) {
     df <- file
   } else {
     message("[read_counts] ERROR: Input must be filename or matrix")
     return(NULL)
   }
-  is_valid <- validate_counts(df)
-  if (!is_valid) {
-    message("[read_counts] WARNING: Counts file has errors")
-    ## return(NULL)
-  }
+
+  ## is_valid <- validate_counts(df)
+  ## if (!is_valid) {
+  ##   message("[read_counts] WARNING: Counts file has errors")
+  ##   ## return(NULL)
+  ## }
 
   ## determine column types (NEED RETHINK!)
-  df1 <- type.convert(data.frame(df, check.names = FALSE), as.is = TRUE)
+  df1 <- type.convert(data.frame(head(df,20), check.names = FALSE), as.is = TRUE)
   col.type <- sapply(df1, class)
   xannot.names <- "gene|symbol|protein|compound|title|description|name|position"
   is.xannot <- grepl(xannot.names, tolower(colnames(df)))
@@ -273,8 +293,9 @@ read_counts <- function(file, first = FALSE, unique = FALSE, paste_char = "_") {
   last.charcol <- tail(char.cols, 1)
   last.charcol
 
-  ## if the rownames are not unique, and some more character columns
-  ## exists, then search for best column and paste after rowname.
+  ## NEED RETHINK. if the rownames are not unique, and some more
+  ## character columns exists, then search for best column and paste
+  ## after rownames.
   if (length(char.cols) > 0 && sum(duplicated(rownames(df)))) {
     ndup <- sapply(char.cols, function(k) {
       sum(duplicated(paste0(rownames(df), "_", df[, k])))
@@ -292,7 +313,7 @@ read_counts <- function(file, first = FALSE, unique = FALSE, paste_char = "_") {
   }
 
   ## convert to numeric if needed (probably yes...)
-  is.numeric.matrix <- all(apply(df, 2, is.numeric))
+  is.numeric.matrix <- all(apply(head(df,20), 2, is.numeric))  
   if (!is.numeric.matrix) {
     message("[read_counts] force to numeric values")
     rn <- rownames(df)
@@ -368,7 +389,7 @@ read_annot <- function(file, unique = TRUE) {
   if (colnames(df)[1] == "") colnames(df)[1] <- "row.names"
 
   ## determine last character column
-  df1 <- type.convert(data.frame(df, check.names = FALSE), as.is = TRUE)
+  df1 <- type.convert(data.frame(head(df,20), check.names = FALSE), as.is = TRUE)
   col.type <- sapply(df1, class)
   xannot.names <- "gene|symbol|protein|compound|title|description|name|position"
   is.xannot <- grepl(xannot.names, tolower(colnames(df)))


### PR DESCRIPTION
**Problem:**
Read_counts() was slow for large (scRNA matrices) mainly due to unneeded type conversion and checking. Up to 50 seconds for 16000x1800 matrix. While fread() reads in 2-3 seconds.

**Solution:**
- Added as.matrix, as.char to read.as_matrix to skip  type conversion when not needed. 
- Skipping pgx.checkINPUT check for read_counts  
- Integer64 are converted directly after fread to numeric. No need to convert to character.