### PR TITLE
Fix #1131: Dataview > Sample info Error in apply: dim(X) must have a positive length

### DIFF
--- a/R/pgx-correlation.R
+++ b/R/pgx-correlation.R
@@ -413,10 +413,14 @@ pgx.testPhenoCorrelation <- function(df, plot = TRUE, cex = 1, compute.pv = TRUE
   rvar <- sub("=.*", "", colnames(Rx))
   Rx[is.nan(Rx)] <- 0
   Rx[is.na(Rx)] <- 0
-  R <- tapply(1:nrow(Rx), rvar, function(i) apply(Rx[c(i, i), ], 2, max, na.rm = TRUE))
+  R <- tapply(1:nrow(Rx), rvar, function(i) apply(Rx[c(i, i), , drop = FALSE], 2, max, na.rm = TRUE))
   R <- do.call(rbind, R)
-  R <- tapply(1:ncol(R), rvar, function(i) apply(R[, c(i, i)], 1, max, na.rm = TRUE))
-  R <- do.call(cbind, R)
+  R <- tapply(1:ncol(R), rvar, function(i) apply(R[, c(i, i), drop = FALSE], 1, max, na.rm = TRUE))
+  if (length(R) == 1) {
+    R <- matrix(R)
+  } else {
+    R <- do.call(cbind, R)
+  }
   R <- t(R / sqrt(diag(R))) / sqrt(diag(R))
   R[is.nan(R)] <- NA
 

--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2075,7 +2075,7 @@ pgx.plotPhenotypeMatrix0 <- function(annot, annot.ht = 5, cluster.samples = TRUE
   if (cluster.samples) {
     annotx <- expandAnnotationMatrix(annot.df)
     hc <- fastcluster::hclust(stats::dist(annotx)) ## cluster samples
-    annot.df <- annot.df[hc$order, ]
+    annot.df <- annot.df[hc$order, , drop = FALSE]
   }
 
   npar <- apply(annot.df, 2, function(x) length(setdiff(unique(x), NA)))


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1131

When R has length 1, it is a vector not a matrix, which breaks subsequent operations. Also, typical `drop = FALSE` missing.

@ivokwee Ask me for dataset to reproduce error and check fix works.