### PR TITLE
Fix #1136: Drug conn not computed for non human species

### DIFF
--- a/R/pgx-drugs.R
+++ b/R/pgx-drugs.R
@@ -100,9 +100,10 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
   FC <- FC[, contrast, drop = FALSE]
 
   if (!obj$organism %in% c("Human", "human")) {
-    human_genes <- ifelse(!is.na(obj$genes$human_ortholog),
+    human_genes <- ifelse(
+      !obj$genes$human_ortholog %in% c("", "-", "NA", NA),
       obj$genes$human_ortholog,
-      obj$genes$symbol
+      toupper(obj$genes$symbol)
     )
     rownames(FC) <- human_genes
   }
@@ -118,8 +119,6 @@ pgx.computeDrugEnrichment <- function(obj, X, xdrugs, drug_info = NULL,
 
   ## first level (rank) correlation
   message("Calculating first level rank correlation ...")
-  jj <- match(rownames(FC), rownames(obj$genes)) ## Enable enrichment for proteomics
-  rownames(FC) <- obj$genes$symbol[jj]
   gg <- intersect(rownames(X), rownames(FC))
 
   if (length(gg) < 20) {


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1136

1. make sure that an empty human_ortholog is when it is NA, "", "-" or "NA"
2. uppercase symbol (for rat)
3. no need to do matching between FC or genes rownames; at this step the rownames of X and FC will forcedly be as "human" as possible, therefore it was not required to do any previous matching