### PR TITLE
Fix #1139: spearman crashes on SA proteomics data (no remove of features without symbol)

### DIFF
--- a/R/gset-meta.r
+++ b/R/gset-meta.r
@@ -89,9 +89,8 @@ gset.fitContrastsWithAllMethods <- function(gmt,
     ## single-sample gene set enrichment using (fast) rank correlation
     xx1 <- X - rowMeans(X, na.rm = TRUE) ## center it...
     xx1 <- apply(xx1, 2, rank, na.last = "keep") ## rank correlation (like spearman)
-    jj <- intersect(rownames(G), rownames(xx1))
     tt <- system.time({
-      zx.rnkcorr <- qlcMatrix::corSparse(G[jj, , drop = FALSE], xx1[jj, ]) ## superfast
+      zx.rnkcorr <- qlcMatrix::corSparse(G, xx1) ## superfast
       rownames(zx.rnkcorr) <- colnames(G)
       colnames(zx.rnkcorr) <- colnames(X)
 

--- a/R/gset-meta.r
+++ b/R/gset-meta.r
@@ -81,8 +81,11 @@ gset.fitContrastsWithAllMethods <- function(gmt,
   zx.gsva <- zx.ssgsea <- zx.rnkcorr <- NULL
   res.gsva <- res.ssgsea <- res.rnkcorr <- NULL
 
-  G <- G[rownames(X), names(gmt), drop = FALSE]
-
+  ## align. gg are symbols.
+  gg <- setdiff(rownames(X), c("",NA))
+  G <- G[gg, names(gmt), drop = FALSE]
+  X <- X[gg, , drop = FALSE]
+  
   if ("spearman" %in% methods) {
     message("fitting contrasts using spearman/limma... ")
 


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1139

## Description
When some symbol was missing, this crashed because it tried to subset the `NA` element which does not exist.

Looking at the code we can see that actually `G` is subsetted by the rownames of `X`(https://github.com/bigomics/playbase/blob/main/R/gset-meta.r#L84), and `xx1` comes from `X`(https://github.com/bigomics/playbase/blob/main/R/gset-meta.r#L90); therefore intersecting rownames of G and xx1 will always be the same.