### PR TITLE
fix reactive labeltype. 

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -1587,7 +1587,7 @@ pgx.plotGeneUMAP <- function(pgx, contrast = NULL, value = NULL,
                              title = NULL, zfix = FALSE,
                              set.par = TRUE, par.sq = FALSE,
                              level = "gene", plotlib = "ggplot",
-                             data = FALSE, labeltype = shiny::reactive("feature")) {
+                             data = FALSE, labeltype = "feature") {
   if (!is.null(contrast)) {
     if (is.numeric(contrast)) contrast <- names(pgx$gx.meta$meta)[contrast]
     res <- NULL
@@ -1633,16 +1633,16 @@ pgx.plotGeneUMAP <- function(pgx, contrast = NULL, value = NULL,
 
   # Rename labels
   if (!is.null(rownames(F))) {
-    rownames(F) <- make.names(playbase::probe2symbol(rownames(F), pgx$genes, labeltype(), fill_na = TRUE), unique = TRUE)
+    rownames(F) <- make.names(playbase::probe2symbol(rownames(F), pgx$genes, labeltype, fill_na = TRUE), unique = TRUE)
   }
   if (!is.null(rownames(pos))) {
-    rownames(pos) <- make.names(playbase::probe2symbol(rownames(pos), pgx$genes, labeltype(), fill_na = TRUE), unique = TRUE)
+    rownames(pos) <- make.names(playbase::probe2symbol(rownames(pos), pgx$genes, labeltype, fill_na = TRUE), unique = TRUE)
   }
   if (!is.null(label)) {
-    label <- make.names(playbase::probe2symbol(label, pgx$genes, labeltype(), fill_na = TRUE), unique = TRUE)
+    label <- make.names(playbase::probe2symbol(label, pgx$genes, labeltype, fill_na = TRUE), unique = TRUE)
   }
   if (!is.null(hilight)) {
-    hilight <- make.names(playbase::probe2symbol(hilight, pgx$genes, labeltype(), fill_na = TRUE), unique = TRUE)
+    hilight <- make.names(playbase::probe2symbol(hilight, pgx$genes, labeltype, fill_na = TRUE), unique = TRUE)
   }
 
   plist <- list()


### PR DESCRIPTION
Should not be here but in parent call. Calling the plotting function in Quarto (non-shiny) will not work like this. Creating report failed. See also branch/PR in omicsplayground. 