### PR TITLE
Fix #1190: WGCNA: non-numeric argument to mathematical function

### DIFF
--- a/R/pgx-init.R
+++ b/R/pgx-init.R
@@ -191,6 +191,19 @@ pgx.initialize <- function(pgx) {
   if (is.null(pgx$organism)) {
     pgx$organism <- playbase::pgx.getOrganism(pgx)
   }
+
+  # Check if human ortholog is empty, if it is
+  # 1) run getHumanOrtholog (maybe it failed on pgx.compute bc server was unreachable)
+  # 2) if still empty, grag the symbols toUpper
+  if (all(is.na(pgx$genes$human_ortholog))) {
+    genes_ho <- getHumanOrtholog(pgx$organism, pgx$genes$symbol)$human
+    if (all(is.na(genes_ho))) {
+      pgx$genes$human_ortholog <- toupper(pgx$genes$symbol)
+    } else {
+      pgx$genes$human_ortholog <- genes_ho
+    }
+  }
+
   if (pgx$organism %in% c("Human", "human") | !is.null(pgx$version)) {
     pgx$families <- lapply(playdata::FAMILIES, function(x) {
       intersect(x, genes)

--- a/R/pgx-wgcna.R
+++ b/R/pgx-wgcna.R
@@ -157,7 +157,7 @@ pgx.wgcna <- function(
   }
 
   ## Do quick geneset analysis using fisher-test (fastest method)
-  gmt <- getGSETS_playbase(pattern = "HALLMARK|GOBP|^C[1-9]")
+  gmt <- getGSETS_playbase(pattern = "HALLMARK|GOBP|^C[1-9]|GO_BP")
   gse <- NULL
   bg <- rownames(pgx$X)
   bg <- probe2symbol(bg, pgx$genes, query = "human_ortholog")


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/compare/fix-1190

1) Adds GO_BP, otherwise we were searching GOBP which is not there anymore.

2) Check human ortholog on initialize; some datasets might have missing human_ortholog field, this handles those cases.