### PR TITLE
Fix #1175: Data upload:: Can't assign to the same column twice in the same query (duplicates detected)

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -81,6 +81,9 @@ read.as_matrix <- function(file, skip_row_check = FALSE, as.char = TRUE,
   # Convert x from data.table to matrix. With as.char = TRUE,
   # as.matrix() does not return mixed types (such as in dataframes).
   if (as.char) {
+    ## drop duplicated columns
+    ## otherwise as.char will crash
+    x <- x[,which(duplicated(colnames(x))) := NULL]
     colnames_x <- colnames(x)[-1]
     x[, c(colnames_x) := lapply(.SD, as.character), .SDcols = colnames_x]
   }


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1175

Read matrix function crashes with duplicated columns if as.char=TRUE

Now the checks work as expected

![image](https://github.com/user-attachments/assets/c1bea953-d0ab-4cf2-90db-9bed17e41d98)
