### PR TITLE
Fix #1203: no rows to aggregate

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -1866,7 +1866,7 @@ pgx.plotExpression <- function(pgx, probe, comp, logscale = TRUE,
 
   ## -------------- remove others
   if (showothers == FALSE && any(grepl("other", xgroup))) {
-    jj <- grep("other", xgroup, invert = TRUE)
+    jj <- !xgroup %in% "other"
     xgroup <- factor(xgroup[jj], levels = setdiff(levels(xgroup), "other"))
     gx <- gx[jj]
   }


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1203

We add "other" on line 1829, therefore we can directly look for it instead of grep; by doing grep there is one user dataset where comparison is xxother_vs_yyother, which makes jj become character(0) and plot to crash. by just checking "other" plot works as expected

## Before
![image](https://github.com/user-attachments/assets/cc9f03aa-1f63-49ca-8937-3689838d4cd6)

## After
![image](https://github.com/user-attachments/assets/81c29933-ef49-4195-bb0c-718ba2c40b2c)
