### PR TITLE
Fix #1219: Diff expression > Top features: factor level [3] is duplicated

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -1840,7 +1840,7 @@ pgx.plotExpression <- function(pgx, probe, comp, logscale = TRUE,
     xgroup <- as.character(xgroup)
 
     levels0 <- group.names
-    if ("other" %in% xgroup) levels0 <- c(levels0, "other")
+    if ("other" %in% xgroup && !"other" %in% levels0) levels0 <- c(levels0, "other")
     xgroup <- factor(xgroup, levels = levels0)
   }
 


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1219

if the contrast is XX_vs_other, levels0 will already contain "other", so duplicating it will crash the next line with "duplicate factors"

![image](https://github.com/user-attachments/assets/57b4a1d7-28f3-4511-a516-b2ebbafa6f88)
