### PR TITLE
fix: check if creator is not null

### DIFF
--- a/R/pgx-pgxinfo.R
+++ b/R/pgx-pgxinfo.R
@@ -45,7 +45,7 @@ pgxinfo.add <- function(pgxinfo, pgx, remove.old = TRUE) {
   date <- ifelse(is.null(pgx$date), this.date, as.character(pgx$date))
   dataset.name <- pgx$name
 
-  creator <- ifelse("creator" %in% names(pgx), pgx$creator, "")
+  creator <- ifelse(!is.null(pgx$creator), pgx$creator, "")
 
   this.info <- c(
     dataset = dataset.name,


### PR DESCRIPTION
Found a case where the creator field is present on the pgx, but it's value is `NULL`, which makes this line to crash.

To reproduce the error: put on your data folder the dataset pgx I have shared on Slack.

Since pgx is a list, if "creator" field is not found, it will evaluate to NULL, so this expression will be OK.