### PR TITLE
fix-annotation-probetype-entrezid

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -266,8 +266,10 @@ getGeneAnnotation.ANNOTHUB <- function(
     jj <- match(names(locs), annot$ENTREZID)
     annot$MAP <- NA
     annot$MAP[jj] <- unname(locs)
-    cls <- setdiff(colnames(annot), "ENTREZID")
-    annot <- annot[, cls, drop = FALSE]
+    if (probe_type != "ENTREZID") {
+      cls <- setdiff(colnames(annot), "ENTREZID")
+      annot <- annot[, cls, drop = FALSE]
+    }
   }
 
   # some organisms do not provide symbol but rather gene name (e.g. yeast)


### PR DESCRIPTION
Fixes  Playbase issue #186

If probe_type is ENTREZID, we retain ENTREZID column in the annot data matrix.