### PR TITLE
Fix #1276: Sample information multiple errors

### DIFF
--- a/R/pgx-pheno.R
+++ b/R/pgx-pheno.R
@@ -396,6 +396,9 @@ expandPhenoMatrix <- function(M, drop.ref = TRUE, keep.numeric = FALSE, check = 
   y.isnum <- (y.class %in% c("numeric", "integer"))
   kk <- which(y.isnum | (!y.isnum & nlevel > 1 & nratio < 0.66))
   if (length(kk) == 0) {
+    kk <- which(y.isnum | (!y.isnum & nlevel > 1 ))
+  }
+  if (length(kk) == 0) {
     return(NULL)
   }
   a1 <- a1[, kk, drop = FALSE]


### PR DESCRIPTION
This closes https://github.com/bigomics/omicsplayground/issues/1276

If `kk` length is zero, re-do the subsetting and allow `nratio` to be 1, this indicates that the phenotype information of the data is poor (as can be seen on the table), nevertheless it's good to allow the plots to be displayed so the user can see that information clearly.

![image](https://github.com/user-attachments/assets/5117f604-0185-48e0-88c6-13d232d92638)
