### PR TITLE
fix: make sure contrasts is new style

### DIFF
--- a/R/pgx-init.R
+++ b/R/pgx-init.R
@@ -140,6 +140,10 @@ pgx.initialize <- function(pgx) {
     }
     pgx$contrasts <- new.contr
   }
+  # If contrasts is present and numeric, got to run contrastAsLabels
+  if (is.numeric(pgx$contrasts)) {
+    pgx$contrasts <- contrastAsLabels(pgx$contrasts)
+  }
 
 
   ## ----------------------------------------------------------------


### PR DESCRIPTION
Old datasets were not being initialized properly (e.g. public data `GSE72056-scmelanoma.pgx`).

Contrasts on this data set is numeric (non 0,1,-1) coded, which does not trigger the correct conversion. After passing through all the contrast check code, double check that the resulting contrasts table is not numeric, if so, pass through `contrastAsLabels`.