### PR TITLE
Fix #1310: Heatmap, filter by one protein/gene breaks it

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -5653,6 +5653,9 @@ pgx.splitHeatmapFromMatrix <- function(X, annot = NULL, idx = NULL, splitx = NUL
 
   ## ------ split Y-axis (genes) by factor
   hc.order <- function(x) {
+    if (nrow(x) == 1) {
+      return(rownames(x))
+    }
     suppressWarnings(dd <- stats::as.dist(1 - stats::cor(t(x), use = "pairwise")))
     if (sum(is.na(dd))) dd[is.na(dd) | is.nan(dd)] <- 1
     hc <- fastcluster::hclust(dd, method = "ward.D2")
@@ -5660,7 +5663,7 @@ pgx.splitHeatmapFromMatrix <- function(X, annot = NULL, idx = NULL, splitx = NUL
   }
   if (!is.null(idx)) {
     if (row_clust) {
-      kk <- tapply(rownames(X), idx, function(k) c(hc.order(X[k, ]), "   "))
+      kk <- tapply(rownames(X), idx, function(k) c(hc.order(X[k, , drop = FALSE]), "   "))
     } else {
       kk <- tapply(rownames(X), idx, function(k) c(k, "   "))
     }
@@ -5676,7 +5679,7 @@ pgx.splitHeatmapFromMatrix <- function(X, annot = NULL, idx = NULL, splitx = NUL
     idx <- rev(idx)
   } else {
     if (row_clust) {
-      kk <- hc.order(X[, ])
+      kk <- hc.order(X[, , drop = FALSE])
       X <- X[kk, ]
     }
   }


### PR DESCRIPTION
Linked to https://github.com/bigomics/omicsplayground/issues/1310

When there are just two distinct genes (or more generally, if a cluster has 1 gene), the `hc.order` has to return just the rownames of x, as current approach returns `NULL`, therefore there is a crash downstream.