### PR TITLE
fix bug: non-human gene sets that only shows GO (fix for issue #1318)

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -624,9 +624,22 @@ getCustomAnnotation <- function(probes, custom_annot = NULL) {
 #' }
 #' @import data.table
 #' @export
-probe2symbol <- function(probes, annot_table, query = "symbol", fill_na = FALSE) {
+probe2symbol <- function(probes, annot_table, query = "symbol",
+                         key = NULL, fill_na = FALSE) {
+
   # Prepare inputs
-  query_col <- annot_table[probes, query]
+  annot_table <- cbind( rownames = rownames(annot_table), annot_table )
+  probes1 <- setdiff(probes, c(NA,""))
+  if(is.null(key) || !key %in% colnames(annot_table)) {
+    key <- which.max(apply(annot_table, 2, function(a) sum(probes1 %in% a)))
+  }
+  if(is.null(key)) {
+    stop("[probe2symbol] FATAL. could not get key column.")
+  }
+  
+  # match query
+  ii <- match( probes, annot_table[,key] )
+  query_col <- annot_table[ii, query]
 
   # Deal with NA
   if (fill_na) {


### PR DESCRIPTION
This fixes issue OPG #1318  (https://github.com/bigomics/omicsplayground/issues/1318)  "Mouse data in ENSEMBL format only shows GO terms (v3.5.1+master241218)"

- Moved probe2symbol 
- Rewrote probe2symbol with key matching.