### PR TITLE
Check protein is NA

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -1990,7 +1990,7 @@ info.add_hyperlinks <- function(info, feature, datatype,
   
   if (length(uniprot) == 0) {
     this.uniprot <- NULL
-  } else if(length(uniprot) == 1 && uniprot[1]=="") {
+  } else if(length(uniprot) == 1 && uniprot[1]=="" || is.na(uniprot[1])) {
     this.uniprot <- NULL
   } else {
     uniprot <- sort(unique(unlist(strsplit(uniprot, split=';'))))


### PR DESCRIPTION
Arabidopsis dataset gives this error

![image](https://github.com/user-attachments/assets/b0f5607a-3857-450c-b351-3bee0c00e311)

Which comes from https://github.com/bigomics/playbase/blob/devel/R/pgx-annot.R#L1993 ; where `uniprot[1]` is `NA`, therefore we have to take that into account.

After this fix:

![image](https://github.com/user-attachments/assets/3b74b33a-9b8b-4cd4-aabf-23c2f228f757)
