### PR TITLE
feat: match rows on BC methods

### DIFF
--- a/R/pgx-correct.R
+++ b/R/pgx-correct.R
@@ -1770,8 +1770,11 @@ compare_batchcorrection_methods <- function(X, samples, pheno, contrasts,
   )
 
   if (length(xlist.init) > 0) xlist <- c(xlist.init, xlist)
+  common_rows <- Reduce(intersect, lapply(xlist, rownames))
+  xlist <- c(
+    lapply(xlist, function(x) x[common_rows, , drop = FALSE])
+  )
   xlist <- xlist[order(names(xlist))]
-  names(xlist)
 
   ## PCA is faster than UMAP
   pos <- NULL


### PR DESCRIPTION
`xlist.init` contains the "uncorrected" and "normalized" counts. Which have all the features uploaded by the user. At this step we are cutting `ntop` features given we are just comparing and visualizing.

For that reason, we must make sure uncorrected and normalized matrices that are passed to tsne or pca downstream, have the same `ntop` features. Not because precision but to avoid un-needed compute time for just visualization purposes.
