### PR TITLE
fix dimension error [CRITICAL]

### DIFF
--- a/R/pgx-init.R
+++ b/R/pgx-init.R
@@ -240,6 +240,8 @@ pgx.initialize <- function(pgx) {
     F <- pgx.getMetaMatrix(pgx)$fc
     F <- rename_by2(F, pgx$genes, "symbol")
     gset.fc <- gset.averageFC(F, pgx$GMT)
+    ii <- match(rownames(pgx$gset.meta$meta[[1]]),rownames(gset.fc))
+    gset.fc <- gset.fc[ii,]
     for (i in 1:nc) {
       pgx$gset.meta$meta[[i]]$meta.fx <- gset.fc[,i]
     }


### PR DESCRIPTION
CRITICAL Fix for crash on older pgx at pgx.initialize genesetfc. Add extra match to ensure size are same.

```
 pgx <- pgx.load("../omicsplayground/data/example-data.pgx")
> pgx <- pgx.initialize(pgx)
[pgx.initialize] initializing pgx object
[pgx.initialize] Recomputing geneset fold-changes
Error in `$<-.data.frame`(`*tmp*`, "meta.fx", value = c(`AGING:Human_bone marrow-derived, hematopoietic stem cells (HSC)_25 years vs 51 years_GDS3942_aging86 (down)` = -0.0307745425772401,  : 
  replacement has 6800 rows, data has 6107
> nc <- length(pgx$gset.meta$meta)
```