### PR TITLE
Add check for NA in counts for DESeq2 and EdgeR

### DIFF
--- a/R/ngs-fit.r
+++ b/R/ngs-fit.r
@@ -147,6 +147,7 @@ ngs.fitContrastsWithAllMethods <- function(counts,
   ## Skip tests that do not tolerate NAs. Inform the user.
   nmissing.counts <- sum(is.na(counts))
   nmissing <- sum(is.na(X))
+  if (nmissing.counts>0 & nmissing==0) counts <- pmax(2**X-1,0)
   
   ## ---------------- t-test methods -------------------
   ttest.mtds <- c("ttest", "ttest.rank", "ttest.welch")
@@ -221,7 +222,7 @@ ngs.fitContrastsWithAllMethods <- function(counts,
       X1 <- X
       mdl <- deseq2.mdls[match(cm.mtds[i], deseq2.mtds)]
       message("[ngs.fitContrastsWithAllMethods] Fitting using ", cm.mtds[i])
-      if (nmissing.counts > 0) {
+      if (nmissing > 0) {
         message("[ngs.fitContrastsWithAllMethods] Missing values detected. Cannot perform ", cm.mtds[i])
         next;
       } else {
@@ -252,7 +253,7 @@ ngs.fitContrastsWithAllMethods <- function(counts,
       X1 <- X
       mdl <- edger.mdls[match(cm.mtds[i], edger.mtds)]
       message("[ngs.fitContrastsWithAllMethods] Fitting using ", cm.mtds[i])
-      if (nmissing.counts > 0) {
+      if (nmissing > 0) {
         message("[ngs.fitContrastsWithAllMethods] Missing values detected. Cannot perform edgeR QL-F test or LRT.")
         next;
       } else {


### PR DESCRIPTION
DESeq2 and EdgeR use counts. Now original counts have NA restored (if any). If data are imputed, pgx$counts has NAs, but pgx$X has no NAs. In such case counts can be computed from X. If data are not imputed, NAs are also present in pgx$X. In this latter case methods not supporting NAs are not run and user is informed.