### PR TITLE
fix: unique pathways

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -252,7 +252,7 @@ pgx.plotEnrichmentDotPlot <- function(pgx, contrast,
   ## cleaning...
   df$pathway <- sub(".Homo.sapiens", "", df$pathway)
   df$pathway <- substring(df$pathway, 1, 60)
-  df$pathway <- factor(df$pathway, levels = rev(df$pathway))
+  df$pathway <- factor(df$pathway, levels = rev(unique(df$pathway)))
 
 
   ggplot2::ggplot(df, ggplot2::aes(x = fx, y = pathway)) +


### PR DESCRIPTION
From client, dataset comparison report fails.

Seems levels are not always unique.

Ask about pgx if required.