### PR TITLE
feat: use fast blas correlation on outlier detection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,6 +68,7 @@ Imports:
     grimon,
     GSVA,
     harmony,
+    HiClimR,
     htmlwidgets,
     igraph,
     iheatmapr,

--- a/R/pgx-outlier.R
+++ b/R/pgx-outlier.R
@@ -6,9 +6,9 @@
 #' @export
 detectOutlierSamples <- function(X, plot = TRUE, par = NULL) {
   ## correlation and distance
-  X <- head(X[order(-matrixStats::rowSds(X, na.rm = TRUE)), ], 4000)
+  X <- head(X[order(-matrixStats::rowSds(X, na.rm = TRUE)), ], 1000)
   X <- X - median(X, na.rm = TRUE)
-  corX <- cor(X, use = "pairwise")
+  corX <- HiClimR::fastCor(X, optBLAS = TRUE)#cor(X, use = "pairwise")
   distX <- as.matrix(dist(t(X)))
 
   ## z-score based on correlation


### PR DESCRIPTION
Make outlier detection faster by:
- Use first 1k (with most SDs) features (down from 4k before)
- Use fast BLAS correlation

Comparison between old and new correlation (speed and results):

``` r
# Benchmark correlation methods
set.seed(42)
n <- 1000
X <- matrix(rnorm(n * n), nrow=n)

# Standard R correlation
t1 <- system.time({
  c1 <- cor(X, use = "pairwise")
})

# BLAS optimized correlation
t2 <- system.time({
  c2 <- HiClimR::fastCor(X, optBLAS = TRUE)
})

# Verify the differences are very small
cat("Max absolute difference:", max(abs(c1 - c2)), "\n")
#> Max absolute difference: 2.553513e-15
```

``` r

cat("Standard cor time:", t1["elapsed"], "\n")
#> Standard cor time: 62.699
```

``` r
cat("BLAS optimized time:", t2["elapsed"], "\n") 
#> BLAS optimized time: 0.301
```

``` r
cat("Speedup:", t1["elapsed"] / t2["elapsed"], "x\n")
#> Speedup: 208.3023 x
```

``` r

# Verify results are the same
c1[1:5,1:5]
#>              [,1]         [,2]        [,3]        [,4]         [,5]
#> [1,]  1.000000000  0.009981927 -0.02140111  0.01490632  0.000290269
#> [2,]  0.009981927  1.000000000 -0.01772655  0.05976000  0.014169312
#> [3,] -0.021401113 -0.017726546  1.00000000 -0.02121393 -0.021450268
#> [4,]  0.014906316  0.059760005 -0.02121393  1.00000000  0.029822074
#> [5,]  0.000290269  0.014169312 -0.02145027  0.02982207  1.000000000
```

``` r
c2[1:5,1:5]
#>              [,1]         [,2]        [,3]        [,4]         [,5]
#> [1,]  1.000000000  0.009981927 -0.02140111  0.01490632  0.000290269
#> [2,]  0.009981927  1.000000000 -0.01772655  0.05976000  0.014169312
#> [3,] -0.021401113 -0.017726546  1.00000000 -0.02121393 -0.021450268
#> [4,]  0.014906316  0.059760005 -0.02121393  1.00000000  0.029822074
#> [5,]  0.000290269  0.014169312 -0.02145027  0.02982207  1.000000000
```

<sup>Created on 2025-06-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>