### PR TITLE
handle-duplicated-features

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -210,7 +210,8 @@ pgx.createPGX <- function(counts,
     if (average.duplicated) {
       message("[pgx.createPGX] ", ndup, " duplicated feature(s) detected. Averaging....")
       counts <- playbase::counts.mergeDuplicateFeatures(counts, is.counts = TRUE)
-      X <- playbase::counts.mergeDuplicateFeatures(X, is.counts = FALSE)
+      if(!is.null(X)) X <- playbase::counts.mergeDuplicateFeatures(X, is.counts = FALSE)
+      if(!is.null(impX)) impX <- playbase::counts.mergeDuplicateFeatures(impX, is.counts = FALSE)
     } else {
       message("[pgx.createPGX] ", ndup, " duplicated feature(s) detected. Making unique to keep all...")
       rownames(counts) <- playbase::make_unique(rownames(counts))


### PR DESCRIPTION
1.  Handle duplicated features (default keep all). User can select to average.
2. Keep counts unaltered unless batch correction is performed.
3. Move BC in pgx.createPGX. Upload code much smaller, cleaner, faster.
Needs https://github.com/bigomics/omicsplayground/pull/1456