### PR TITLE
Fix #1467: When switching the imputation strategy during upload no missing values are shown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,6 +72,7 @@ Imports:
     htmlwidgets,
     igraph,
     iheatmapr,
+    imputeLCMD,
     IntNMF,
     irlba,
     isva,


### PR DESCRIPTION
Playbase is missing a dependency for other impute methods to work correctly.