### PR TITLE
fix: control that probe exists

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2089,7 +2089,7 @@ pgx.plotExpression <- function(pgx,
 
       data <- data.frame(gx = gx, xgroup = xgroup)
       pct.NA <- NULL
-      if (grouped) {
+      if (grouped && probe %in% rownames(pgx$counts)) {
         grs <- unique(as.character(data$xgroup))
         i=1; pct.NA=c()
         for(i in 1:length(grs)) {


### PR DESCRIPTION
control that probe exists, this fct is used on gene/geneset level; PR #294 did not take that into account. this fixes it

barplot on geneset module had an error after merging #294 (example-data):

<img width="4722" height="2022" alt="image" src="https://github.com/user-attachments/assets/b1feeffc-0159-4de7-8a22-a1945033c3de" />

after this:

<img width="4722" height="2022" alt="image" src="https://github.com/user-attachments/assets/c039c012-a7f7-4736-b329-d565063e3c2a" />

I have also checked that on dge the enhancements introduced on #294 are still ok