### PR TITLE
Commented out: ShowProbeType(); clean_dups_inline_probenames()

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -577,14 +577,14 @@ uniprot2gene <- function(uniprots, organism) {
   res[uniprots]
 }
 
-#' Clean up inline duplicated features: eg: feature1;feature1;....
-#'
-#' @export
-clean_dups_inline_probenames <- function(probes) {
-  probes[is.na(probes)] <- ""
-  probes <- sapply(strsplit(probes,split="[;,._]"),function(s) paste(unique(s),collapse=";"))
-  return (probes)
-}
+## #' Clean up inline duplicated features: eg: feature1;feature1;....
+## #'
+## #' @export
+## clean_dups_inline_probenames <- function(probes) {
+##   probes[is.na(probes)] <- ""
+##   probes <- sapply(strsplit(probes,split="[;,._]"),function(s) paste(unique(s),collapse=";"))
+##   return (probes)
+## }
 
 #' non-greedy removal of numerical postfix. Postfix is defined as (1)
 #' last numerical substring after - (minus), or (2) any substring
@@ -1472,83 +1472,83 @@ collapse_by_humansymbol <- function(obj, annot) {
   map.obj
 }
 
-#' @title Show some probe types for selected organism
-#'
-#' @export
-showProbeTypes <- function(organism, keytypes = NULL, use.ah = NULL, n = 10) {
-  if (tolower(organism) == "human") organism <- "Homo sapiens"
-  if (tolower(organism) == "mouse") organism <- "Mus musculus"
-  if (tolower(organism) == "rat") organism <- "Rattus norvegicus"
-  organism
+## #' @title Show some probe types for selected organism
+## #'
+## #' @export
+## showProbeTypes <- function(organism, keytypes = NULL, use.ah = NULL, n = 10) {
+##   if (tolower(organism) == "human") organism <- "Homo sapiens"
+##   if (tolower(organism) == "mouse") organism <- "Mus musculus"
+##   if (tolower(organism) == "rat") organism <- "Rattus norvegicus"
+##   organism
 
-  message(paste("retrieving probe types for", organism, "..."))
+##   message(paste("retrieving probe types for", organism, "..."))
 
-  ## get correct OrgDb database for organism
-  orgdb <- getOrgDb(organism, use.ah = use.ah)
-  if (is.null(orgdb)) {
-    message("[showProbeTypes] ERROR: unsupported organism '", organism, "'\n")
-    return(NULL)
-  }
+##   ## get correct OrgDb database for organism
+##   orgdb <- getOrgDb(organism, use.ah = use.ah)
+##   if (is.null(orgdb)) {
+##     message("[showProbeTypes] ERROR: unsupported organism '", organism, "'\n")
+##     return(NULL)
+##   }
 
-  ## get probe types for organism
-  if (!is.null(keytypes) && keytypes[1] == "*") {
-    keytypes <- AnnotationDbi::keytypes(orgdb)
-  }
-  if (is.null(keytypes)) {
-    keytypes <- c(
-      "SYMBOL", "ENSEMBL", "UNIPROT", "ENTREZID",
-      "GENENAME", "MGI", "TAIR",
-      "ENSEMBLTRANS", "ENSEMBLPROT",
-      "ACCNUM", "REFSEQ"
-    )
-  }
-  keytypes0 <- keytypes
-  keytypes <- intersect(keytypes, AnnotationDbi::keytypes(orgdb))
-  keytypes
+##   ## get probe types for organism
+##   if (!is.null(keytypes) && keytypes[1] == "*") {
+##     keytypes <- AnnotationDbi::keytypes(orgdb)
+##   }
+##   if (is.null(keytypes)) {
+##     keytypes <- c(
+##       "SYMBOL", "ENSEMBL", "UNIPROT", "ENTREZID",
+##       "GENENAME", "MGI", "TAIR",
+##       "ENSEMBLTRANS", "ENSEMBLPROT",
+##       "ACCNUM", "REFSEQ"
+##     )
+##   }
+##   keytypes0 <- keytypes
+##   keytypes <- intersect(keytypes, AnnotationDbi::keytypes(orgdb))
+##   keytypes
 
-  if (length(keytypes) == 0) {
-    message("ERROR: no valid keytypes in: ", keytypes0)
-    return(NULL)
-  }
+##   if (length(keytypes) == 0) {
+##     message("ERROR: no valid keytypes in: ", keytypes0)
+##     return(NULL)
+##   }
 
-  ## example probes
-  keytype0 <- "ENTREZID"
-  suppressMessages(suppressWarnings(
-    probes <- try(head(AnnotationDbi::keys(orgdb, keytype = keytype0), n))
-  ))
-  if ("try-error" %in% class(probes)) {
-    keytype0 <- setdiff(keytypes, "ENTREZID")[1]
-    probes <- try(head(AnnotationDbi::keys(orgdb, keytype = keytype0), n))
-  }
-  keytype0
+##   ## example probes
+##   keytype0 <- "ENTREZID"
+##   suppressMessages(suppressWarnings(
+##     probes <- try(head(AnnotationDbi::keys(orgdb, keytype = keytype0), n))
+##   ))
+##   if ("try-error" %in% class(probes)) {
+##     keytype0 <- setdiff(keytypes, "ENTREZID")[1]
+##     probes <- try(head(AnnotationDbi::keys(orgdb, keytype = keytype0), n))
+##   }
+##   keytype0
 
-  ## Iterate over probe types
-  key_matches <- list()
-  key <- keytypes[1]
-  for (key in keytypes) {
-    ## add symbol and genename on top of key as they will be used to
-    ## count the real number of probe matches
-    probe_matches <- try(
-      suppressMessages(suppressWarnings(
-        AnnotationDbi::select(
-          orgdb,
-          keys = probes,
-          keytype = keytype0,
-          columns = key
-        )
-      )),
-      silent = TRUE
-    )
-    if (!"try-error" %in% class(probe_matches)) {
-      ## set empty character to NA, as we only count not-NA to define probe type
-      types <- probe_matches[, key]
-      types <- setdiff(types, c("", NA))
-      key_matches[[key]] <- head(types, n)
-    }
-  }
+##   ## Iterate over probe types
+##   key_matches <- list()
+##   key <- keytypes[1]
+##   for (key in keytypes) {
+##     ## add symbol and genename on top of key as they will be used to
+##     ## count the real number of probe matches
+##     probe_matches <- try(
+##       suppressMessages(suppressWarnings(
+##         AnnotationDbi::select(
+##           orgdb,
+##           keys = probes,
+##           keytype = keytype0,
+##           columns = key
+##         )
+##       )),
+##       silent = TRUE
+##     )
+##     if (!"try-error" %in% class(probe_matches)) {
+##       ## set empty character to NA, as we only count not-NA to define probe type
+##       types <- probe_matches[, key]
+##       types <- setdiff(types, c("", NA))
+##       key_matches[[key]] <- head(types, n)
+##     }
+##   }
 
-  return(key_matches)
-}
+##   return(key_matches)
+## }
 
 
 #' @title Get all species in AnnotationHub/OrgDB


### PR DESCRIPTION
Commented out: ShowProbeType(); clean_dups_inline_probenames().
Unused. Keep commented out for 2 months after which we can remove.