### PR TITLE
feat: use -999 as NA encoder

### DIFF
--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -708,6 +708,7 @@ sigdb.getConnectivityMatrix <- function(sigdb, select = NULL, genes = NULL,
       length(rowidx), " x ", length(colidx), ")"
     )
     suppressWarnings(X <- as.matrix(tx[rowidx, colidx]))
+    X[X == -999] <- NA
   } else {
     cat("[getConnectivityMatrix] WARNING: could not retrieve matrix\n")
   }


### PR DESCRIPTION
helps avoid random NaN columns appearing when converting from h5 to tiledb

after merging this and putting into prod, requires manually updating libx.v4 everywhere