### PR TITLE
feat: use vroom guess_delim

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -184,10 +184,7 @@ detect_delim <- function(file, delims = c(",", "\t", " ", "|", ":", ";")) {
     }
   }
   if (top_idx == 0) {
-    stop(glue::glue('
-        Could not guess the delimiter.\n
-        {silver("Use `vroom(delim =)` to specify one explicitly.")}
-        '), call. = FALSE)
+    return(",") # default to comma
   }
 
   delims[[top_idx]]


### PR DESCRIPTION
improve delimiter retrieval; comes from antonino public data retrieval having problems with some particular datasets where the delimiter was a space

the function has been modified slightly, if no clear delim is found, we return comma instead of an error