### PR TITLE
fix: typo on class check

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -283,7 +283,7 @@ pgx.dimPlot <- function(X, y, method = c("tsne", "pca", "umap"), nb = NULL, ...)
     X1 <- cbind(X1, X1, X1)
   }
 
-  if (is.null(nb)) nb <- ceiling(min(15, dim(X) / 8))
+  if (is.null(nb)) nb <- ceiling(min(15, dim(X1) / 8))
   for (m in method) {
     if (m == "umap") pos <- try(uwot::umap(t(X1), n_neighbors = max(2, nb)))
     if (m == "tsne") {
@@ -294,7 +294,7 @@ pgx.dimPlot <- function(X, y, method = c("tsne", "pca", "umap"), nb = NULL, ...)
     }
     if (m == "pca") pos <- try(irlba::irlba(X1, nv = 2, nu = 0)$v)
     if (m == "pacmap") pos <- try(pacmap(t(X1)))
-    if ("try-errror" %in% class(pos)) {
+    if ("try-error" %in% class(pos)) {
       pos <- matrix(0, nrow = ncol(X), ncol = 2)
       rownames(pos) <- colnames(X)
       pgx.scatterPlotXY(pos, var = y, title = m, ...)


### PR DESCRIPTION
From hubspot ticket 227804473576

Fixed
1. Check X1 (matrix used) not X (changes nothing really)
2.` try-e**rrr**or` -> `try-e**rr**or` (actual fix)

## Before
<img width="1734" height="1448" alt="image" src="https://github.com/user-attachments/assets/743c87f2-d3e1-49ab-a7d1-743974f3c4e8" />


## After
<img width="1734" height="1448" alt="image" src="https://github.com/user-attachments/assets/88aaa388-fe59-4ece-a3c2-95975efe60c3" />

