### PR TITLE
fix: tagDuplicates does not work for rownames

### DIFF
--- a/R/gx-heatmap.r
+++ b/R/gx-heatmap.r
@@ -290,7 +290,7 @@ gx.splitmap <- function(gx, split = 5, splitx = NULL,
   ## give unique name if duplicated
   ndup <- sum(duplicated(rownames(gx)))
   if (ndup > 0) {
-    rownames(gx) <- tagDuplicates(rownames(gx))
+    rownames(gx) <- make.unique(rownames(gx))
     if (!is.null(row.annot)) rownames(row.annot) <- rownames(gx)
   }
 


### PR DESCRIPTION
Fixes Hubspot ticket 248327225579.

Our playbase function adds trailing spaces to try and make rownames unique, however it does not work properly. We need to use base R function make.unique to make sure the rownames are unique and not get errors.

## Before
<img width="2674" height="1632" alt="image" src="https://github.com/user-attachments/assets/86040407-68f7-41e3-95a1-7e4e86c33639" />

## After
<img width="2674" height="1632" alt="image" src="https://github.com/user-attachments/assets/9a2f6a14-19fa-468b-9178-7da2c2266629" />

