### PR TITLE
fix detect delim. determine from first 10 lines except header.

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -162,18 +162,16 @@ read.as_matrix <- function(file, skip_row_check = FALSE, as.char = TRUE,
 #'
 detect_delim <- function(file, delims = c(",", "\t", " ", "|", ":", ";")) {
   # Code extracted from vroom:::guess_delim (version 1.5.7)
-  lines <- readLines(file, n = 1)
+  lines <- readLines(file, n = 10)[-1]  
+  lines <- paste(lines,collapse='\n')
+  
   # blank text within quotes
   lines <- gsub('"[^"]*"', "", lines)
 
   splits <- lapply(delims, strsplit, x = lines, useBytes = TRUE, fixed = TRUE)
-
   counts <- lapply(splits, function(x) table(lengths(x)))
-
   num_fields <- vapply(counts, function(x) as.integer(names(x)[[1]]), integer(1))
-
   num_lines <- vapply(counts, function(x) (x)[[1]], integer(1))
-
   top_lines <- 0
   top_idx <- 0
   for (i in seq_along(delims)) {


### PR DESCRIPTION
Problem: detection of delim fails with "metabolomics-kegg" example data. 

Possible cause: header/colnames has lots of spaces in names, detects space as delim (instead comma)

Solution: Fix detect delim. Improved determine from first 10 lines except header. 