### PR TITLE
fix: hclust fails if gx has NAs

### DIFF
--- a/R/gx-heatmap.r
+++ b/R/gx-heatmap.r
@@ -616,6 +616,7 @@ gx.splitmap <- function(gx, split = 5, splitx = NULL,
     if (any(is.na(gx))) {
       gx2 <- imputeMissing(gx, method = "SVD2")
       cluster_rows <- as.dendrogram(hclust(dist(gx2)))
+      rm(gx2)
     } else {
       cluster_rows <- as.dendrogram(hclust(dist(gx)))
     }


### PR DESCRIPTION
Control case where gx has NAs which make the heatmap fail

## Before
<img width="1180" height="730" alt="image" src="https://github.com/user-attachments/assets/9ad52260-d2e2-455f-8ebd-4e9eaa6435b6" />

## After
<img width="1180" height="730" alt="image" src="https://github.com/user-attachments/assets/7f4a14a6-afb6-42df-9db3-fc732c1df7ad" />
