### PR TITLE
improvement: if no sc params is pased function should run

### DIFF
--- a/R/pgx-singlecell.R
+++ b/R/pgx-singlecell.R
@@ -1082,6 +1082,9 @@ pgx.createSingleCellPGX <- function(counts,
 
   sc.membership <- NULL
   do.supercells <- sc_compute_settings[["compute_supercells"]]
+  if (is.null(do.supercells)) {
+    do.supercells <- FALSE
+  }
 
   if (do.supercells || ncol(counts) > 10000) {
     if (do.supercells) {


### PR DESCRIPTION
`  if (do.supercells || ncol(counts) > 10000) {`

Fails without this control when no sc params list is passed (which is the default of this function).

Makes testing work.