### PR TITLE
improvement: replace GSVA functions with replaid

### DIFF
--- a/R/compute2-genesets.R
+++ b/R/compute2-genesets.R
@@ -20,6 +20,7 @@
 compute_testGenesets <- function(pgx,
                                  custom.geneset = list(gmt = NULL, info = NULL),
                                  test.methods = c("gsva", "camera", "fgsea"),
+                                 use.replaid = TRUE,
                                  remove.outputs = TRUE) {
   if (!"X" %in% names(pgx)) {
     stop("[compute_testGenesets] FATAL : object must have normalized matrix X")
@@ -84,11 +85,11 @@ compute_testGenesets <- function(pgx,
   gset.meta <- gset.fitContrastsWithAllMethods(
     gmt = gmt,
     X = X1,
-    Y = Y,
     G = G,
     design = design,
     contr.matrix = contr.matrix,
     methods = test.methods,
+    use.replaid = use.replaid,
     mc.threads = 1,
     mc.cores = NULL,
     batch.correct = TRUE

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -805,7 +805,8 @@ pgx.computePGX <- function(pgx,
     pgx <- compute_testGenesets(
       pgx = pgx,
       custom.geneset = custom.geneset,
-      test.methods = gset.methods
+      test.methods = gset.methods,
+      use.replaid = TRUE
     )
 
     ## Cluster by genes

--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -539,17 +539,17 @@ pgx.computeGeneSetExpression <- function(X, gmt, method = NULL,
 
   gmt.size <- sapply(gmt, function(x) sum(x %in% rownames(X)))
   gmt <- gmt[gmt.size >= min.size]
+  gg <- rownames(X)
+  G <- gmt2mat(gmt, bg = gg)
 
   S <- list()
   if ("gsva" %in% method) {
-    S[["gsva"]] <- GSVA::gsva(X, gmt, method = "gsva")
+    S[["gsva"]] <- plaid::replaid.gsva(X, G)    
   }
   if ("ssgsea" %in% method) {
-    S[["ssgsea"]] <- GSVA::gsva(X, gmt, method = "ssgsea", min.sz = 1)
+    S[["ssgsea"]] <- plaid::replaid.ssgsea(X, G)        
   }
   if (any(method %in% c("spearman", "average"))) {
-    gg <- rownames(X)
-    G <- gmt2mat(gmt, bg = gg)
     if ("spearman" %in% method) {
       rho <- t(G[gg, ]) %*% scale(apply(X[gg, ], 2, rank)) / sqrt(nrow(X) - 1)
       rho[is.na(rho)] <- 0


### PR DESCRIPTION
GSVA and ssGSEA (GSVA package) are too slow for large matrices and large number of genesets. We replace them with plaid::replaid.gsva and plaid::replaid.ssgsea functions which are way faster (> 100x).

- add parameter use.replaid=TRUE to replace computation with replaid functions. 

