### PR TITLE
fix: no organism with custom geneset can go through

### DIFF
--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -799,7 +799,8 @@ pgx.computePGX <- function(pgx,
   ## ------------------ gene set tests -----------------------
   if (!is.null(progress)) progress$inc(0.2, detail = "testing gene sets")
 
-  if (pgx$organism != "No organism" && !is.null(pgx$GMT) && nrow(pgx$GMT) > 0) {
+  if ((pgx$organism != "No organism" && !is.null(pgx$GMT) && nrow(pgx$GMT) > 0) ||
+      (pgx$organism == "No organism" && !is.null(custom.geneset$gmt))) {
     message("[pgx.computePGX] testing genesets...")
 
     pgx <- compute_testGenesets(


### PR DESCRIPTION
From customer feedback:

When we select cutom organism and provide a custom gmt file, we should run geneset analysis.