### PR TITLE
fix bug GMT initialization for nonhuman

### DIFF
--- a/R/pgx-functions.R
+++ b/R/pgx-functions.R
@@ -4,8 +4,6 @@
 ##
 
 
-
-
 #' Default merge by columns (cbind) with shared features on
 #' rows. Features are union of input matrices.
 #'
@@ -54,7 +52,7 @@ cbind_sparse_matrix <- function(m1, m2) {
   m1 <- m1[gene_vector, , drop = FALSE]
   m2 <- m2[gene_vector, , drop = FALSE]
 
-  # Combine the matrices column-wise
+  # Combine the matrices column-wise  
   combined_gmt <- cbind(m1, m2)
 
   # If duplicated genesets, then keep only the largest one


### PR DESCRIPTION
**Crash:**  Computation of WGCNA gives GMT dimension error for work (C. Elegans) and other non-human example data. Previously successful.

**Possible cause**:  latest WGCNA changes use not pgx$GMT but full GSETxGENES and is not fullly compatible with non-human species.  Latter is preferred to get better annotation of all modules.

**Solution**:  merging pgx$GMT (species specific GMT) and GSETxGENES (human)



<img width="1969" height="270" alt="image" src="https://github.com/user-attachments/assets/a2b42a1a-248c-431a-9fca-2303b7f86039" />