### PR TITLE
fix: keep group column

### DIFF
--- a/R/pgx-mofa.R
+++ b/R/pgx-mofa.R
@@ -7,6 +7,7 @@ pgx.compute_mofa <- function(pgx, kernel = "MOFA", numfactors = 8,
                              factorizations = TRUE,
                              compute.enrichment = TRUE,
                              compute.lasagna = TRUE) {
+
   has.prefix <- (mean(grepl(":", rownames(pgx$X))) > 0.8)
   is.multiomics <- (pgx$datatype == "multi-omics" && has.prefix)
 
@@ -383,10 +384,7 @@ mofa.compute <- function(xdata,
   colnames(V) <- colnames(W)
 
   ## Covariate x Factor correlation
-  Y <- samples
-  Y$sample <- NULL
-  Y$group <- NULL
-  Y <- expandPhenoMatrix(Y, drop.ref = FALSE)
+  Y <- expandPhenoMatrix(samples, drop.ref = FALSE, keep.numeric=TRUE)
   Y <- as.matrix(Y)
   Z <- cor(Y, F, use = "pairwise")
   Z[is.na(Z)] <- 0


### PR DESCRIPTION
1. Keep group column. This breaks if samples matrix has only group column. We should not remove it as default. expandPhenoMatrix will remove useless columns already. 
2. Keep numeric columns for correlation. Correlation should be able to handle this. 