### PR TITLE
fix: bring down 1*nsign for bg genes, to help fisher

### DIFF
--- a/R/pgx-signature.R
+++ b/R/pgx-signature.R
@@ -173,8 +173,8 @@ pgx.correlateSignatureH5 <- function(fc, h5.file, nsig = 100, ntop = 200, nperm 
   ## --------------------------------------------------
   fc.up <- fc[fc > 0]
   fc.dn <- fc[fc < 0]
-  top.up <- head(names(sort(-fc.up)), 3 * nsig) ## RETHINK!
-  top.dn <- head(names(sort(+fc.dn)), 3 * nsig)
+  top.up <- head(names(sort(-fc.up)), nsig)
+  top.dn <- head(names(sort(+fc.dn)), nsig)
   top.fc <- unique(c(top.up, top.dn))
   bg <- intersect(names(fc), rn)
   system.time({


### PR DESCRIPTION
Prevent background gene list to become the same as genes (for low features datasets). This fixes fisher and sim exp tab. 

Related to https://github.com/bigomics/omicsplayground/pull/1647