### PR TITLE
fix: use same default as before, no dot removal

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2237,7 +2237,7 @@ pgx.plotPhenotypeMatrix <- function(annot) {
 pgx.plotPhenotypeMatrix0 <- function(annot, annot.ht = 5, cluster.samples = TRUE) {
   cvar <- pgx.getCategoricalPhenotypes(
     annot,
-    min.ncat = 2, max.ncat = 10, remove.dup = FALSE
+    min.ncat = 2, max.ncat = 10, remove.dup = FALSE, remove.dot = FALSE
   )
   fvar <- pgx.getNumericalPhenotypes(annot)
   annot.cvar <- annot[, cvar, drop = FALSE]


### PR DESCRIPTION
9 months ago we added the remove.dot code for multiomics/metabolomics https://github.com/bigomics/playbase/commit/7540bb06aaf930fc2ce4d6bbde590af60ff193a6, which defaults to true. On client data this causes a problem on dataview tab, with this PR we use the same default as before, which solves the issue