### PR TITLE
fix: filter out NA row

### DIFF
--- a/R/pgx-read.R
+++ b/R/pgx-read.R
@@ -452,6 +452,7 @@ read_Olink_NPX <- function(NPX_data) {
   counts.df <- reshape2::dcast(NPX, fm, value.var = npx.id, fun.aggregate = mean)
   counts <- as.matrix(counts.df[sapply(counts.df, is.numeric)])
   rownames(counts) <- counts.df[, feature.id]
+  counts <- counts[!is.na(rownames(counts)), ]
 
   return(counts)
 }


### PR DESCRIPTION
From client data, filter a NA that breaks QC/BC tab of data upload