### PR TITLE
fix non-ascii names for MOFA

### DIFF
--- a/R/pgx-mofa.R
+++ b/R/pgx-mofa.R
@@ -228,9 +228,8 @@ mofa.compute <- function(xdata,
     ## MOFA does not like non-ascii names
     xdata.names <- lapply(xdata, rownames)
     safe.names <- lapply(xdata.names, iconv2ascii)
-    xdata2 <- xdata
-    for(i in 1:length(xdata2)) rownames(xdata2[[i]]) <- safe.names[[i]]
-    obj <- MOFA2::create_mofa(xdata2, groups = NULL)
+    for(i in 1:length(xdata)) rownames(xdata[[i]]) <- safe.names[[i]]
+    obj <- MOFA2::create_mofa(xdata, groups = NULL)
 
     ## 'group' is used by MOFA
     samples1 <- samples


### PR DESCRIPTION
MOFA gives error if feature names have non-ascii characters. We solve this by temporarily force iconv2ascii and later put back original names. 

<img width="1213" height="418" alt="image" src="https://github.com/user-attachments/assets/ace9977a-68c5-4e51-812f-a488d64a21a0" />
