### PR TITLE
feat: gprofiler on trycatch

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -1535,7 +1535,11 @@ detect_probetype <- function(organism, probes, orgdb = NULL,
       species = organism, method = "gprofiler",
       output_format = "id", verbose = FALSE
     )
-    gp.out <- gprofiler2::gconvert(probesx, organism = gp.organism, target = "UNIPROT_GN_ACC")
+    gp.out <- tryCatch({
+      gprofiler2::gconvert(probesx, organism = gp.organism, target = "UNIPROT_GN_ACC")
+    }, error = function(e) {
+      return(NULL)
+    })
     if (!is.null(gp.out)) {
       key_matches["GPROFILER"] <- length(unique(gp.out$input)) / length(probesx)
     }


### PR DESCRIPTION
When there is no internet gprofiler fails and probe check crashes, this should be avoided for on-prem deploys with no internet access