### PR TITLE
Add error handling fallback in getOrthoSpecies function

### DIFF
--- a/R/pgx-annot.R
+++ b/R/pgx-annot.R
@@ -555,6 +555,10 @@ getGeneAnnotation.ANNOTHUB <- function(
 getOrthoSpecies <- function(organism, use = c("table", "map")[1]) {
   if (use == "map") {
     species <- try(orthogene::map_species(organism, method = "gprofiler", verbose = FALSE))
+    if(inherits(species,"try-error") || is.null(species)) {
+      species <- NULL
+      use <- "table"  ## try again using table
+    }
   }
   if (use == "table") {
     S <- playbase::SPECIES_TABLE


### PR DESCRIPTION
When orthogene::map_species fails or returns NULL, the function now falls back to using the table method instead of failing. This improves robustness when the gprofiler method is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)