### PR TITLE
fix: explicitly set rownames in gsea.enplotly to prevent add_segments crash on protein datasets

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -2670,6 +2670,7 @@ gsea.enplotly <- function(fc, gset, cex = 1, main = NULL, xlab = NULL, ticklen =
 
   cc <- sign(fc) * rank(abs(fc))
   df <- data.frame(x = rank(-fc), y = fc, trace = rnk.trace, cc = cc)
+  rownames(df) <- make.unique(names(fc))
 
   ## downsample
   ii <- which(rownames(df) %in% gset)


### PR DESCRIPTION
From client demo: (ask me for dataset to reproduce)

### Before
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/c92738df-497c-4252-8ee4-29fd87ccaf4e" />

### After
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/88349f53-ede7-4e2b-bec3-205eb2c7e76d" />


