### PR TITLE
fix: duplicate column names in pgx.plotActivation heatmap

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -6626,7 +6626,7 @@ pgx.plotActivation <- function(pgx,
   }
 
   dim(score)
-  colnames(score) <- substring(colnames(score), 1, 30)
+  colnames(score) <- make.unique(shortstring(colnames(score), n = 30, dots = 3))
   rownames(score) <- substring(rownames(score), 1, row.nchar)
   colnames(score) <- paste0(colnames(score), " ")
 


### PR DESCRIPTION
By using just substring for colnames, we can end up with columns with the same names. This is specially plausible for long contrast names (seen on client data, that's why I investigated into it).

I changed to shortstring (cuts text in the middle, not on the end of the string) + added make.unique to ensure we don't loose columns.

Ask me for data to reproduce if required.