### PR TITLE
feat: symmetric x-axis limits on static volcano plot to match dynamic

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -1392,7 +1392,10 @@ ggVolcano <- function(x,
   df$name <- gsub("[\\'\\`-]", "", df$name)
 
   if (is.null(ylim)) ylim <- max(y, na.rm = TRUE) * 1.1
-  if (is.null(xlim)) xlim <- range(x, na.rm = TRUE)  
+  if (is.null(xlim)) {
+    max.absx <- max(abs(x), na.rm = TRUE)
+    xlim <- c(-1, 1) * max.absx
+  }
 
   plt <- ggplot2::ggplot(df, ggplot2::aes(x = fc, y = y)) +
     ggplot2::geom_point(


### PR DESCRIPTION
On plotly we use symmetric x-axis on volcano plots. This PR is to make sure ggplot volcanos have the same behaviour. Issue noted by prospect client.