### PR TITLE
feat: add npc arg to compare_batchcorrection_methods

### DIFF
--- a/R/pgx-correct.R
+++ b/R/pgx-correct.R
@@ -1751,7 +1751,8 @@ compare_batchcorrection_methods <- function(X,
                                             ntop = 4000,
                                             xlist.init = list(),
                                             ref = NULL,
-                                            evaluate = TRUE) {
+                                            evaluate = TRUE,
+                                            npc = 2) {
   if (is.null(pheno) && is.null(contrasts)) {
     stop("must give either pheno vector or contrasts matrix")
   }
@@ -1801,10 +1802,11 @@ compare_batchcorrection_methods <- function(X,
     })
   } else {
     message("Computing PCA clustering...")
+    npc_eff <- max(2, min(npc, min(sapply(xlist, function(x) min(dim(x)))) - 1))
     for (i in 1:length(xlist)) {
       set.seed(1234)
-      pca <- irlba::irlba(t2(xlist[[i]]), nu = 2, nv = 2)
-      pos[[names(xlist)[i]]] <- pca$u[, 1:2]
+      pca <- irlba::irlba(t2(xlist[[i]]), nu = npc_eff, nv = npc_eff)
+      pos[[names(xlist)[i]]] <- pca$u[, seq_len(npc_eff), drop = FALSE]
       pca.varexp[[names(xlist)[i]]] <- (pca$d^2 / sum(pca$d^2)) * 100
     }
   }


### PR DESCRIPTION
Adds an `npc` argument (default 2) so to keep more than the first two principal components. irlba's nu/nv are clamped against matrix dimensions so small datasets still work

requires https://github.com/bigomics/omicsplayground/pull/1777