### PR TITLE
fix: filter X matrix to graph nodes in lasagna.solve

### DIFF
--- a/R/pgx-mofa.R
+++ b/R/pgx-mofa.R
@@ -2977,7 +2977,8 @@ lasagna.solve <- function(obj, pheno, max_edges = 100, value.type = "rho",
   }
 
   if (is.null(graph)) graph <- obj$graph
-  X <- obj$X
+  nn <- igraph::V(graph)$name
+  X <- obj$X[nn,]
   y <- obj$Y[, pheno]
 
   ## check if phenotype was coded -1/0/1


### PR DESCRIPTION
## Summary
- Fix row mismatch in `lasagna.solve`: subset `X` to graph node names before solving.

## Test plan
- [ ] Verify `lasagna.solve` runs without index errors on graphs with partial node coverage