### PR TITLE
fix: guard empty gmt in mx.create_metabolite_sets

### DIFF
--- a/R/pgx-metabolomics.R
+++ b/R/pgx-metabolomics.R
@@ -1320,6 +1320,11 @@ mx.create_metabolite_sets <- function(annot, gmin = 0, metmin = 5,
   }
 
   ## order on size, take out duplicated pathways
+  if (length(gmt) == 0L) {
+    info("[pgx.add_GMT] no metabolite sets matched annotation; returning empty list")
+    # prevent gmt[order(-sapply(gmt, length))] crash
+    return(list())
+  }
   gmt <- gmt[order(-sapply(gmt, length))]
   gmt <- gmt[!duplicated(names(gmt))]
   pw.id <- gsub(".*\\[|\\]", "", names(gmt))


### PR DESCRIPTION
Simple fix for empty metabolomics match. Hit on plant dataset —
annotation mapped to zero metabolite sets, gmt empty, downstream
gmt[order(-sapply(gmt, length))] + gmt2mat() crash, pgx.add_GMT die,
compute fail.

Return list() early with info() log. Compute finish clean.