### PR TITLE
Fix/reports vocab

### DIFF
--- a/R/ai-report-common.R
+++ b/R/ai-report-common.R
@@ -268,6 +268,53 @@
   )))
 }
 
+#' Collect deterministic methods provenance from a pgx object.
+#'
+#' Reads what the pipeline actually did for a report slice, so the Methods block
+#' can name the real engines, normalization, and imputation instead of a
+#' hardcoded transcriptomics list. The engines are the column names of the
+#' slice's first meta result (\code{slice$meta[[1]]$q}); normalization is
+#' \code{pgx$norm_method}; imputation is the method recorded on
+#' \code{pgx$model.parameters$impute_method} (see \code{compute_testGenes}).
+#'
+#' @param pgx PGX object.
+#' @param slice Module slice (e.g. \code{pgx$gx.meta} or \code{pgx$gset.meta}).
+#' @return Named list with \code{engines} (character vector), \code{norm}
+#'   (string), and \code{impute} (string).
+collect_methods <- function(pgx, slice) {
+  meta <- slice$meta %||% list()
+  engines <- character(0)
+  if (length(meta)) {
+    qmat <- meta[[1]]$q
+    if (!is.null(qmat)) engines <- colnames(qmat)
+  }
+  list(
+    engines = engines,
+    norm = pgx$norm_method %||% "not recorded",
+    impute = pgx$model.parameters$impute_method %||% "none (no imputation applied)"
+  )
+}
+
+# Assemble the parameter block shared by every module's methods template:
+# experiment identity, counts, the engines that ran (label + engine-filtered
+# bibliography), provenance (norm/impute), and datatype vocabulary. norm/impute
+# are harmless extras for templates that omit them (e.g. pathways).
+.methods_params <- function(pgx, slice, module) {
+  prov <- collect_methods(pgx, slice)
+  eng <- omicsai::omicsai_methods_engines(prov$engines, module)
+  c(list(
+    experiment = .ai_report_get(pgx, "label"),
+    date = format(Sys.Date(), "%Y-%m-%d"),
+    n_contrasts = length(names(slice$meta %||% list())),
+    n_samples = tryCatch(nrow(pgx$samples), error = function(e) NA_integer_),
+    n_features = tryCatch(nrow(pgx$X), error = function(e) NA_integer_),
+    engines = eng$label,
+    norm = prov$norm,
+    impute = prov$impute,
+    bibliography = eng$bibliography
+  ), omicsai::omicsai_datatype_vocab(pgx$datatype))
+}
+
 #' Build a deterministic methods appendix for a report.
 #'
 #' Loads the report-specific methods template, substitutes the provided

--- a/R/ai-report-de.R
+++ b/R/ai-report-de.R
@@ -111,18 +111,19 @@
   )
 }
 
-.de_contrast_detail <- function(pgx, slice, ntop) {
+.de_contrast_detail <- function(pgx, slice, ntop, feature = "gene") {
+  labels <- c(gene = feature)
   details <- vapply(names(slice$meta), function(contrast) {
     mx <- slice$meta[[contrast]]
     up <- .de_gene_table(pgx, mx, "up", n = ntop)
     down <- .de_gene_table(pgx, mx, "down", n = ntop)
     up_table <- if (nrow(up)) {
-      paste(omicsai::omicsai_format_mdtable(up), collapse = "\n")
+      paste(omicsai::omicsai_format_mdtable(up, col_labels = labels), collapse = "\n")
     } else {
       "(none)"
     }
     down_table <- if (nrow(down)) {
-      paste(omicsai::omicsai_format_mdtable(down), collapse = "\n")
+      paste(omicsai::omicsai_format_mdtable(down, col_labels = labels), collapse = "\n")
     } else {
       "(none)"
     }
@@ -148,11 +149,15 @@ de_build_report_tables <- function(slice, pgx, ntop = 50L, cross_n = 50L) {
     stop("DE report requires at least one contrast", call. = FALSE)
   }
 
+  vocab <- omicsai::omicsai_datatype_vocab(pgx$datatype)
+  feature <- vocab$feature
+
   sample_metadata <- .ai_report_get(pgx, "sample_metadata")
   contrast_summary <- .de_contrast_summary(pgx, slice)
   cross_contrast <- .de_cross_contrast_table(pgx, slice, n = cross_n)
-  contrast_detail <- .de_contrast_detail(pgx, slice, ntop = ntop)
-  params <- list(
+  contrast_detail <- .de_contrast_detail(pgx, slice, ntop = ntop,
+                                         feature = feature)
+  params <- c(list(
     experiment_info = .ai_report_get(
       pgx, "experiment_info",
       slice = slice,
@@ -163,10 +168,11 @@ de_build_report_tables <- function(slice, pgx, ntop = 50L, cross_n = 50L) {
       omicsai::omicsai_format_mdtable(contrast_summary), collapse = "\n"
     ),
     cross_contrast_table = paste(
-      omicsai::omicsai_format_mdtable(cross_contrast), collapse = "\n"
+      omicsai::omicsai_format_mdtable(
+        cross_contrast, col_labels = c(gene = feature)), collapse = "\n"
     ),
     contrast_detail = contrast_detail
-  )
+  ), vocab)
 
   template <- omicsai::omicsai_load_template(
     .ai_report_prompt_path("de", "de_report_data.md")
@@ -182,14 +188,8 @@ de_build_report_tables <- function(slice, pgx, ntop = 50L, cross_n = 50L) {
 }
 
 de_build_methods <- function(slice, pgx) {
-  params <- list(
-    experiment = .ai_report_get(pgx, "label"),
-    date = format(Sys.Date(), "%Y-%m-%d"),
-    n_contrasts = length(names(slice$meta %||% list())),
-    n_samples = tryCatch(nrow(pgx$samples), error = function(e) NA_integer_),
-    n_features = tryCatch(nrow(pgx$X), error = function(e) NA_integer_)
-  )
-  build_report_methods("de", "de_methods.md", params = params)
+  build_report_methods("de", "de_methods.md",
+                       params = .methods_params(pgx, slice, "de"))
 }
 
 ai.de.create_report <- function(pgx, slice, ai) {

--- a/R/ai-report-pathways.R
+++ b/R/ai-report-pathways.R
@@ -180,14 +180,8 @@ pathways_build_report_tables <- function(slice, pgx, ntop = 50L,
 }
 
 pathways_build_methods <- function(slice, pgx) {
-  params <- list(
-    experiment = .ai_report_get(pgx, "label"),
-    date = format(Sys.Date(), "%Y-%m-%d"),
-    n_contrasts = length(names(slice$meta %||% list())),
-    n_samples = tryCatch(nrow(pgx$samples), error = function(e) NA_integer_),
-    n_features = tryCatch(nrow(pgx$X), error = function(e) NA_integer_)
-  )
-  build_report_methods("pathways", "pathways_methods.md", params = params)
+  build_report_methods("pathways", "pathways_methods.md",
+                       params = .methods_params(pgx, slice, "pathways"))
 }
 
 ai.pathways.create_report <- function(pgx, slice, ai) {

--- a/R/ai-report-pathways.R
+++ b/R/ai-report-pathways.R
@@ -28,6 +28,24 @@
   term
 }
 
+# Per-geneset meta effect for one contrast, with a fallback direction.
+# meta.fx (the average member-gene fold-change) is NaN for sets whose member
+# genes are absent from the matrix -- pervasive in multi-omics (layer-prefixed
+# rows miss the bare-symbol GMT) and sparse proteomics -- which would otherwise
+# make the report drop genuinely significant sets. Where meta.fx is undefined
+# but per-method effects (mx$fc) exist, fall back to their mean so the set keeps
+# a direction and is reported.
+.pathways_meta_fx <- function(mx, keep) {
+  eff <- mx$meta.fx[keep]
+  bad <- !is.finite(eff)
+  if (any(bad) && !is.null(mx$fc)) {
+    fc <- as.matrix(mx$fc)[keep, , drop = FALSE]
+    fallback <- rowMeans(fc, na.rm = TRUE)
+    eff[bad] <- fallback[bad]
+  }
+  eff
+}
+
 .pathways_contrast_landscape <- function(pgx, fx, q, q_threshold = 0.05) {
   rows <- lapply(colnames(fx), function(contrast) {
     effect <- fx[, contrast]
@@ -128,7 +146,7 @@ pathways_build_report_tables <- function(slice, pgx, ntop = 50L,
   if (!any(keep)) {
     stop("Pathway report requires pathway-oriented terms", call. = FALSE)
   }
-  fx <- sapply(slice$meta, function(mx) mx$meta.fx[keep])
+  fx <- sapply(slice$meta, .pathways_meta_fx, keep = keep)  # meta.fx + fallback
   q <- sapply(slice$meta, function(mx) mx$meta.q[keep])
   if (is.null(dim(fx))) {
     fx <- matrix(fx, ncol = 1L)

--- a/R/ai-report-prompt.R
+++ b/R/ai-report-prompt.R
@@ -53,17 +53,17 @@
     stop("omicsai package required for AI report generation", call. = FALSE)
   }
   fragments <- .ai_report_prompt_fragments(module)
-  context <- if (length(context_vars)) {
-    omicsai::frag(fragments$context, context_vars)
-  } else {
-    omicsai::frag(fragments$context)
-  }
+  # Datatype-aware vocabulary: resolved once and injected into every prompt
+  # fragment so modality nouns ({{feature}}, {{quantity}}, {{analysis}}, ...)
+  # are filled from pgx$datatype rather than hardcoded transcriptomics wording.
+  vocab <- omicsai::omicsai_datatype_vocab(pgx$datatype)
+  context_params <- utils::modifyList(vocab, context_vars)
   prompt <- omicsai::report_prompt(
-    role = omicsai::frag("system_base"),
-    task = omicsai::frag("text/report"),
+    role = omicsai::frag("system_base", vocab),
+    task = omicsai::frag("text/report", vocab),
     species = omicsai::omicsai_species_prompt(pgx$organism),
-    context = context,
-    board_rules = omicsai::frag(fragments$rules),
+    context = omicsai::frag(fragments$context, context_params),
+    board_rules = omicsai::frag(fragments$rules, vocab),
     data = data
   )
   omicsai::build_prompt(prompt)

--- a/R/compute2-genes.R
+++ b/R/compute2-genes.R
@@ -73,7 +73,10 @@ compute_testGenes <- function(pgx,
     design = design,
     contr.matrix = contr.matrix,
     exp.matrix = exp.matrix,
-    group = stat.group
+    group = stat.group,
+    ## imputation method recorded upstream (createPGX), surfaced for the
+    ## deterministic AI-report methods block; NULL when no imputation ran.
+    impute_method = pgx$impute_method %||% "none (no imputation applied)"
   )
   pgx$model.parameters <- model.parameters
 

--- a/R/pgx-compute.R
+++ b/R/pgx-compute.R
@@ -592,11 +592,13 @@ pgx.createPGX <- function(counts,
       xlist <- playbase::runBatchCorrectionMethods(X, batch, pheno, methods = mm, ntop = Inf)
       cX <- xlist[[mm]]
     } else {
+      impute_method <- "SVD2"
+      pgx$impute_method <- impute_method ## recorded for the AI-report methods block
       is.mox <- is.multiomics(rownames(X))
       if (is.mox) {
-        impX <- imputeMissing.mox(X, method = "SVD2")
+        impX <- imputeMissing.mox(X, method = impute_method)
       } else {
-        impX <- imputeMissing(X, method = "SVD2")
+        impX <- imputeMissing(X, method = impute_method)
       }
       xlist <- playbase::runBatchCorrectionMethods(impX, batch, pheno, methods = mm, ntop = Inf)
       cX <- xlist[[mm]]

--- a/tests/testthat/test-ai-report.R
+++ b/tests/testthat/test-ai-report.R
@@ -21,3 +21,28 @@ test_that(".ai_report_normheadings delegates heading spacing to omicsai", {
 
   expect_equal(.ai_report_normheadings(input), expected)
 })
+
+test_that(".pathways_meta_fx recovers direction when meta.fx is NaN", {
+  # Reproduces the GSEA "no enrichment" bug: meta.fx is NaN (member-gene average
+  # undefined for sparse/multi-omics sets) while per-method effects exist.
+  mx <- list(
+    meta.fx = c(GS1 = NaN, GS2 = NaN, GS3 = NaN),
+    meta.q  = c(GS1 = 0.001, GS2 = 0.01, GS3 = 0.2),
+    fc = matrix(c(1.2, -0.8, NA, 0.9, -1.1, NA), nrow = 3,
+                dimnames = list(c("GS1", "GS2", "GS3"), c("gsva", "fgsea")))
+  )
+  eff <- .pathways_meta_fx(mx, rep(TRUE, 3))
+
+  expect_true(is.finite(eff[["GS1"]]) && eff[["GS1"]] > 0)  # elevated
+  expect_true(is.finite(eff[["GS2"]]) && eff[["GS2"]] < 0)  # suppressed
+  expect_true(is.nan(eff[["GS3"]]))                         # no per-method fc
+
+  # The report's significance filter now counts sets previously dropped.
+  significant <- is.finite(eff) & is.finite(mx$meta.q) & mx$meta.q < 0.05
+  expect_equal(sum(significant), 2L)
+})
+
+test_that(".pathways_meta_fx leaves finite meta.fx untouched", {
+  mx <- list(meta.fx = c(A = 1.5, B = -2.0), fc = NULL)
+  expect_equal(.pathways_meta_fx(mx, c(TRUE, TRUE)), c(A = 1.5, B = -2.0))
+})


### PR DESCRIPTION
## Summary

Wires datatype vocabulary and provenance into the AI report data blocks, and fixes a pathway-enrichment direction bug. 

## Changes

- Wire datatype vocabulary and provenance into AI reports: pass the pgx datatype through to the report builders so the data blocks (and the omicsai prompts they feed) use the correct feature/quantity/analysis terms.
- Recover pathway-enrichment direction when `meta.fx` is `NaN`: fall back so elevated/suppressed classification stays correct instead of dropping.
- Remove ## Minor Findings section

## Files

`R/ai-report-common.R`, `R/ai-report-de.R`, `R/ai-report-pathways.R`,
`R/ai-report-prompt.R`, `R/compute2-genes.R`, `R/pgx-compute.R`, plus
`tests/testthat/test-ai-report.R`.

## Tests

`test-ai-report.R` extended and passing.
