### PR TITLE
feat: thread AI-report token usage onto the pgx report slot

### DIFF
--- a/R/ai-report-prompt.R
+++ b/R/ai-report-prompt.R
@@ -76,9 +76,17 @@
   cfg <- omicsai::omicsai_config(model = ai$llm_model,
                                  system_prompt = bp$system)
   res <- omicsai::omicsai_gen_text(bp$board, config = cfg)
+  ## Preserve omicsai's usage list verbatim (a plain list from
+  ## .omicsai_extract_usage(), not the S7 object) so downstream telemetry reads
+  ## its native field names (total_tokens, input_tokens_fresh/cached,
+  ## output_tokens, reasoning_tokens, cache_hit_rate); attach the model used so
+  ## a recorded report event can attribute cost to it.
+  usage <- res$metadata$usage
+  if (!is.null(usage)) usage$model <- ai$llm_model
   list(
     report = .ai_report_normheadings(res$text),
     prompt = paste0("# SYSTEM\n\n", bp$system,
-                    "\n\n---\n\n# BOARD\n\n", bp$board)
+                    "\n\n---\n\n# BOARD\n\n", bp$board),
+    usage  = usage
   )
 }

--- a/R/ai-report.R
+++ b/R/ai-report.R
@@ -171,14 +171,22 @@ pgx.update_reports <- function(pgx, ai = NULL) {
       for (key in names(out)) {
         slot_name <- paste0(module, "_", key)
         pgx$ai[[slot_name]] <- list(
-          report = .ai_report_normheadings(out[[key]]$report),
-          prompt = out[[key]]$prompt
+          report     = .ai_report_normheadings(out[[key]]$report),
+          prompt     = out[[key]]$prompt,
+          usage      = out[[key]]$usage,
+          created_at = as.numeric(Sys.time()),
+          edited     = FALSE,
+          edited_at  = ""
         )
       }
     } else {
       pgx$ai[[module]] <- list(
-        report = .ai_report_normheadings(out$report),
-        prompt = out$prompt
+        report     = .ai_report_normheadings(out$report),
+        prompt     = out$prompt,
+        usage      = out$usage,
+        created_at = as.numeric(Sys.time()),
+        edited     = FALSE,
+        edited_at  = ""
       )
     }
   }


### PR DESCRIPTION
## What

AI report generation returns token usage from omicsai, but playbase dropped it before it reached the pgx object, so downstream apps couldn't meter report cost. 

## Changes

- `.ai_report_run_prompt()` keeps `res$metadata$usage` (previously discarded) and **preserves omicsai's native field names verbatim** (`total_tokens`, `input_tokens_fresh/cached`, `output_tokens`, `reasoning_tokens`, `cache_hit_rate`), attaching the `model` used. No renaming — the app's telemetry sink reads these names 1:1.
- `pgx.update_reports()` widens both create-path slots (single + multi) with `usage`, `created_at`, `edited=FALSE`, `edited_at=""` — giving each report provenance for dedup and manual-edit tracking. Stored as a plain list (not the S7 usage object) so long-lived `.pgx` files don't drift across package versions.

## Testing

- Existing `ai-report` tests green.
- Verified live end-to-end: regenerating a report writes a priced token row (model + fresh/cached/output/reasoning breakdown).
