### PR TITLE
fix(lasagna): plotly edge lines were white, not orange/purple

### DIFF
--- a/R/pgx-plotting.R
+++ b/R/pgx-plotting.R
@@ -7124,7 +7124,8 @@ plotlyLasagna <- function(df, znames = NULL, cex = 1, edges = NULL) {
         idx <- as.vector(t(as.matrix(ee[, 1:2])))
         dfe <- rbind(df1[, c("x", "y", "z")], df2[, c("x", "y", "z")])[idx, ]
         dfe$pair_id <- as.vector(mapply(rep, 1:nrow(ee), 2))
-        dfe$col <- c("darkorange3", "magenta4")[1 + (ee[, 3] > 0)]
+        ## hex, not R colour names: plotly.js cannot parse "darkorange3"/"magenta4"
+        dfe$col <- rep(c("#CD6600", "#8B008B")[1 + (ee[, 3] > 0)], each = 2)
 
         fig <- fig %>%
           plotly::add_trace(


### PR DESCRIPTION
the palette is set on R as `darkorange3`/`magenta4`. Those are R colournames, plotly.js can't parse them, so the line colour never resolves

## before
<img width="705" height="696" alt="image" src="https://github.com/user-attachments/assets/77ea5f3e-7254-4c1a-9954-262ca18f9730" />

## after
<img width="682" height="690" alt="image" src="https://github.com/user-attachments/assets/3da48cb2-3038-4a3a-9894-cf46d1055070" />
