### PR TITLE
fix: tolerate whitespace around ';' in reorder_uniprots (client bug)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -299,8 +299,8 @@ sum_treps <- function(counts, trep_var = "") {
 #' @param lengths Character vector of feature lengths, collapsed with ";". Default NULL.
 #' @export
 reorder_uniprots <- function(feature, lengths = NULL, verbose = FALSE) {
-  ff <- strsplit(as.character(feature), ";")[[1]]
-  ff <- ff[nzchar(trimws(ff))]
+  ff <- trimws(strsplit(as.character(feature), ";")[[1]])
+  ff <- ff[nzchar(ff)]
 
   if (all(as.character(feature) %in% c("", "NA", NA))) {
     return(list(feature = feature, lengths = lengths))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -17,3 +17,13 @@ test_that("mem.proc returns default value on non-Linux systems", {
 #'
 
 #' Test for dbg
+
+
+#' Test for reorder_uniprots
+test_that("reorder_uniprots tolerates spaces around ';' (client bug)", {
+  # Swiss-Prot (Q02978) must outrank TrEMBL (I3L1P8) regardless of spacing.
+  expect_equal(reorder_uniprots("I3L1P8;Q02978")$feature, "Q02978;I3L1P8")
+  expect_equal(reorder_uniprots("I3L1P8; Q02978")$feature, "Q02978;I3L1P8")
+  expect_equal(reorder_uniprots("I3L1P8;   Q02978")$feature, "Q02978;I3L1P8")
+  expect_equal(reorder_uniprots(" I3L1P8 ; Q02978 ")$feature, "Q02978;I3L1P8")
+})


### PR DESCRIPTION
## Client complaint

A client reported that UniProt ID ranking fails when a feature has **multiple semicolon-separated IDs with a space after the `;`**:

> Works for `"I3L1P8;Q02978"`; doesn't work for `"I3L1P8; Q02978"`. Need to work when there is one or multiple spaces.

The engine is supposed to prioritise Swiss-Prot (`Q02978`) over TrEMBL (`I3L1P8`), canonical over isoforms, longer sequences as tiebreak — and it does, **as long as there is no space after the semicolon**.

## Root cause

`reorder_uniprots()` (`R/utils.R`) split the feature string on `;` but never actually trimmed the tokens — `trimws()` was only used as a *filter predicate*, not applied to the values:

```r
ff <- strsplit(as.character(feature), ";")[[1]]
ff <- ff[nzchar(trimws(ff))]      # trims only for the nzchar() test
```

So `" Q02978"` kept its leading space. The Swiss-Prot test `grep("^[OPQ][0-9]", ...)` then missed (the `^` anchor hit the space), demoting the Swiss-Prot ID to TrEMBL — and the stray space leaked into the output feature string.

## Fix

Trim the tokens themselves (one line). Handles one or multiple spaces, and padding anywhere:

```r
ff <- trimws(strsplit(as.character(feature), ";")[[1]])
ff <- ff[nzchar(ff)]
```

## Reprex — before/after

Loads the *real* `reorder_uniprots()` from `origin/main` (before) and from this branch's working tree (after). The function is base-R only, so we pull just its definition from each version of `R/utils.R` — no package build needed.

```r
get_reorder <- function(src_lines) {
  env <- new.env()
  eval(parse(text = src_lines), envir = env)
  env$reorder_uniprots
}

before <- get_reorder(system2("git", c("show", "origin/main:R/utils.R"), stdout = TRUE))
after  <- get_reorder(readLines("R/utils.R"))

cases <- c(
  "I3L1P8;Q02978",       # baseline, no space  -> already worked
  "I3L1P8; Q02978",      # one space           -> client's failing case
  "I3L1P8;   Q02978",    # multiple spaces
  " I3L1P8 ; Q02978 "    # stray padding everywhere
)
```

**BEFORE (`origin/main`)** — a space demotes Swiss-Prot `Q02978` to last, and the stray space leaks into the output:

```r
sapply(cases, function(x) before(x)$feature)
#>       I3L1P8;Q02978      I3L1P8; Q02978    I3L1P8;   Q02978    I3L1P8 ; Q02978
#>     "Q02978;I3L1P8"    "I3L1P8; Q02978"  "I3L1P8;   Q02978" " I3L1P8 ; Q02978 "
```

**AFTER (this branch)** — every variant ranks Swiss-Prot first, no stray spaces:

```r
sapply(cases, function(x) after(x)$feature)
#>     I3L1P8;Q02978    I3L1P8; Q02978  I3L1P8;   Q02978  I3L1P8 ; Q02978
#>   "Q02978;I3L1P8"   "Q02978;I3L1P8"   "Q02978;I3L1P8"   "Q02978;I3L1P8"

sapply(cases, function(x) after(x)$feature == "Q02978;I3L1P8")
#>     I3L1P8;Q02978    I3L1P8; Q02978  I3L1P8;   Q02978  I3L1P8 ; Q02978
#>              TRUE              TRUE              TRUE              TRUE
```

## Tests

Added a regression test in `tests/testthat/test-utils.R` covering the no-space, one-space, multi-space, and padded cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
